### PR TITLE
Added the possibility to export merged network through merging view.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,11 @@
             <version>${powsybl-core.version}</version>
         </dependency>
         <dependency>
+            <groupId>com.powsybl</groupId>
+            <artifactId>powsybl-iidm-mergingview</artifactId>
+            <version>${powsybl-core.version}</version>
+        </dependency>
+        <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
             <version>${springfox.version}</version>

--- a/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
+++ b/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
@@ -10,8 +10,9 @@ import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.datasource.ResourceDataSource;
 import com.powsybl.commons.datasource.ResourceSet;
 import com.powsybl.iidm.import_.Importers;
-import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.*;
 import com.powsybl.network.store.client.NetworkStoreService;
+import com.powsybl.network.store.client.PreloadingStrategy;
 import org.apache.commons.compress.utils.IOUtils;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,10 +34,11 @@ import java.util.UUID;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.BDDMockito.given;
 import static org.mockito.ArgumentMatchers.any;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -98,7 +100,7 @@ public class NetworkConversionTest {
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_JSON))
                     .andReturn();
 
-            given(networkStoreClient.getNetwork(any(UUID.class))).willReturn(network);
+            given(networkStoreClient.getNetwork(any(UUID.class), eq(PreloadingStrategy.COLLECTION))).willReturn(network);
             mvcResult = mvc.perform(get("/v1/networks/{networkUuid}/export/{format}", UUID.randomUUID().toString(), "XIIDM"))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_OCTET_STREAM))
@@ -107,5 +109,189 @@ public class NetworkConversionTest {
             assertEquals("attachment; filename*=UTF-8''20140116_0830_2D4_UX1_pst.xiidm", mvcResult.getResponse().getHeader("content-disposition"));
             assertTrue(mvcResult.getResponse().getContentAsString().startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
         }
+    }
+
+    @Test
+    public void testWithMergingView() throws Exception {
+        UUID testNetworkId1 = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e4");
+        UUID testNetworkId2 = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e5");
+        UUID testNetworkId3 = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e6");
+
+        given(networkStoreClient.getNetwork(testNetworkId1, PreloadingStrategy.COLLECTION)).willReturn(createNetwork("1_"));
+        given(networkStoreClient.getNetwork(testNetworkId2, PreloadingStrategy.COLLECTION)).willReturn(createNetwork("2_"));
+        given(networkStoreClient.getNetwork(testNetworkId3, PreloadingStrategy.COLLECTION)).willReturn(createNetwork("3_"));
+
+        MvcResult mvcResult = mvc.perform(get("/v1/networks/{networkUuid}/export/{format}", testNetworkId1.toString(), "XIIDM")
+                                          .param("networkUuid", testNetworkId2.toString())
+                                          .param("networkUuid", testNetworkId3.toString()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_OCTET_STREAM))
+                .andReturn();
+
+        assertEquals("attachment; filename*=UTF-8''merged_network.xiidm", mvcResult.getResponse().getHeader("content-disposition"));
+        assertTrue(mvcResult.getResponse().getContentAsString().startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>"));
+    }
+
+    public Network createNetwork(String prefix) {
+        Network network = NetworkFactory.findDefault().createNetwork(prefix + "network", "test");
+        Substation p1 = network.newSubstation()
+                .setId(prefix + "P1")
+                .setCountry(Country.FR)
+                .setTso("RTE")
+                .setGeographicalTags("A")
+                .add();
+        Substation p2 = network.newSubstation()
+                .setId(prefix + "P2")
+                .setCountry(Country.FR)
+                .setTso("RTE")
+                .setGeographicalTags("B")
+                .add();
+        VoltageLevel vlgen = p1.newVoltageLevel()
+                .setId(prefix + "VLGEN")
+                .setNominalV(24.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        VoltageLevel vlhv1 = p1.newVoltageLevel()
+                .setId(prefix + "VLHV1")
+                .setNominalV(380.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        VoltageLevel vlhv2 = p2.newVoltageLevel()
+                .setId(prefix + "VLHV2")
+                .setNominalV(380.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        VoltageLevel vlload = p2.newVoltageLevel()
+                .setId(prefix + "VLLOAD")
+                .setNominalV(150.0)
+                .setTopologyKind(TopologyKind.BUS_BREAKER)
+                .add();
+        Bus ngen = vlgen.getBusBreakerView().newBus()
+                .setId(prefix + "NGEN")
+                .add();
+        Bus nhv1 = vlhv1.getBusBreakerView().newBus()
+                .setId(prefix + "NHV1")
+                .add();
+        Bus nhv2 = vlhv2.getBusBreakerView().newBus()
+                .setId(prefix + "NHV2")
+                .add();
+        Bus nload = vlload.getBusBreakerView().newBus()
+                .setId(prefix + "NLOAD")
+                .add();
+        network.newLine()
+                .setId(prefix + "NHV1_NHV2_1")
+                .setVoltageLevel1(vlhv1.getId())
+                .setBus1(nhv1.getId())
+                .setConnectableBus1(nhv1.getId())
+                .setVoltageLevel2(vlhv2.getId())
+                .setBus2(nhv2.getId())
+                .setConnectableBus2(nhv2.getId())
+                .setR(3.0)
+                .setX(33.0)
+                .setG1(0.0)
+                .setB1(386E-6 / 2)
+                .setG2(0.0)
+                .setB2(386E-6 / 2)
+                .add();
+        network.newLine()
+                .setId(prefix + "NHV1_NHV2_2")
+                .setVoltageLevel1(vlhv1.getId())
+                .setBus1(nhv1.getId())
+                .setConnectableBus1(nhv1.getId())
+                .setVoltageLevel2(vlhv2.getId())
+                .setBus2(nhv2.getId())
+                .setConnectableBus2(nhv2.getId())
+                .setR(3.0)
+                .setX(33.0)
+                .setG1(0.0)
+                .setB1(386E-6 / 2)
+                .setG2(0.0)
+                .setB2(386E-6 / 2)
+                .add();
+        int zb380 = 380 * 380 / 100;
+        p1.newTwoWindingsTransformer()
+                .setId(prefix + "NGEN_NHV1")
+                .setVoltageLevel1(vlgen.getId())
+                .setBus1(ngen.getId())
+                .setConnectableBus1(ngen.getId())
+                .setRatedU1(24.0)
+                .setVoltageLevel2(vlhv1.getId())
+                .setBus2(nhv1.getId())
+                .setConnectableBus2(nhv1.getId())
+                .setRatedU2(400.0)
+                .setR(0.24 / 1300 * zb380)
+                .setX(Math.sqrt(10 * 10 - 0.24 * 0.24) / 1300 * zb380)
+                .setG(0.0)
+                .setB(0.0)
+                .add();
+        int zb150 = 150 * 150 / 100;
+        TwoWindingsTransformer nhv2Nload = p2.newTwoWindingsTransformer()
+                .setId(prefix + "NHV2_NLOAD")
+                .setVoltageLevel1(vlhv2.getId())
+                .setBus1(nhv2.getId())
+                .setConnectableBus1(nhv2.getId())
+                .setRatedU1(400.0)
+                .setVoltageLevel2(vlload.getId())
+                .setBus2(nload.getId())
+                .setConnectableBus2(nload.getId())
+                .setRatedU2(158.0)
+                .setR(0.21 / 1000 * zb150)
+                .setX(Math.sqrt(18 * 18 - 0.21 * 0.21) / 1000 * zb150)
+                .setG(0.0)
+                .setB(0.0)
+                .add();
+        double a = (158.0 / 150.0) / (400.0 / 380.0);
+        nhv2Nload.newRatioTapChanger()
+                .beginStep()
+                .setRho(0.85f * a)
+                .setR(0.0)
+                .setX(0.0)
+                .setG(0.0)
+                .setB(0.0)
+                .endStep()
+                .beginStep()
+                .setRho(a)
+                .setR(0.0)
+                .setX(0.0)
+                .setG(0.0)
+                .setB(0.0)
+                .endStep()
+                .beginStep()
+                .setRho(1.15f * a)
+                .setR(0.0)
+                .setX(0.0)
+                .setG(0.0)
+                .setB(0.0)
+                .endStep()
+                .setTapPosition(1)
+                .setLoadTapChangingCapabilities(true)
+                .setRegulating(true)
+                .setTargetV(158.0)
+                .setTargetDeadband(0)
+                .setRegulationTerminal(nhv2Nload.getTerminal2())
+                .add();
+        vlload.newLoad()
+                .setId(prefix + "LOAD")
+                .setBus(nload.getId())
+                .setConnectableBus(nload.getId())
+                .setP0(600.0)
+                .setQ0(200.0)
+                .add();
+        Generator generator = vlgen.newGenerator()
+                .setId(prefix + "GEN")
+                .setBus(ngen.getId())
+                .setConnectableBus(ngen.getId())
+                .setMinP(-9999.99)
+                .setMaxP(9999.99)
+                .setVoltageRegulatorOn(true)
+                .setTargetV(24.5)
+                .setTargetP(607.0)
+                .setTargetQ(301.0)
+                .add();
+        generator.newMinMaxReactiveLimits()
+                .setMinQ(-9999.99)
+                .setMaxQ(9999.99)
+                .add();
+        return network;
     }
 }


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR introduces the possibility to use multiple network uuids as query parameters for network export in order to create a merging view and thus export the merged network.


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, only one network uuid can be given in export query, preventing the export of a merging view composed of multiple networks.


**What is the new behavior (if this is a feature change)?**
Multiple network uuids (of a merging view) can now be passed as query parameters for network export query, allowing the export of a merging view network.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
