### PR TITLE
Import a cgmes case using provided boundaries

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/CgmesCaseDataSourceClient.java
+++ b/src/main/java/com/powsybl/network/conversion/server/CgmesCaseDataSourceClient.java
@@ -1,0 +1,61 @@
+/**
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.conversion.server;
+
+import com.powsybl.cases.datasource.CaseDataSourceClient;
+import com.powsybl.commons.PowsyblException;
+import com.powsybl.network.conversion.server.dto.BoundaryInfos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.client.RestTemplate;
+
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
+ */
+public class CgmesCaseDataSourceClient extends CaseDataSourceClient {
+    private static final Logger LOGGER = LoggerFactory.getLogger(CgmesCaseDataSourceClient.class);
+
+    public static final String TPBD_FILE_REGEX = "^(.*?(__ENTSOE_TPBD_).*(\\.xml))$";
+    public static final String EQBD_FILE_REGEX = "^(.*?(__ENTSOE_EQBD_).*(\\.xml))$";
+
+    private List<BoundaryInfos> boundaries;
+
+    public CgmesCaseDataSourceClient(RestTemplate restTemplate, UUID caseUuid, List<BoundaryInfos> boundaries) {
+        super(restTemplate, caseUuid);
+        this.boundaries = boundaries;
+    }
+
+    @Override
+    public InputStream newInputStream(String fileName) {
+        if (!fileName.matches(EQBD_FILE_REGEX) && !fileName.matches(TPBD_FILE_REGEX)) {
+            return super.newInputStream(fileName);
+        } else {
+            Optional<BoundaryInfos> replacingBoundary;
+            if (fileName.matches(EQBD_FILE_REGEX)) {
+                replacingBoundary = boundaries.stream().filter(b -> b.getFilename().matches(EQBD_FILE_REGEX)).findFirst();
+            } else {
+                replacingBoundary = boundaries.stream().filter(b -> b.getFilename().matches(TPBD_FILE_REGEX)).findFirst();
+            }
+            if (replacingBoundary.isPresent()) {
+                LOGGER.info("Using boundary file {} with id {} to replace original boundary file {}",
+                    replacingBoundary.get().getFilename(),
+                    replacingBoundary.get().getId(),
+                    fileName);
+                return new ByteArrayInputStream(replacingBoundary.get().getBoundary().getBytes(StandardCharsets.UTF_8));
+            } else {
+                throw new PowsyblException("No replacing boundary available for replacement of boundary " + fileName + " !!");
+            }
+        }
+    }
+}

--- a/src/main/java/com/powsybl/network/conversion/server/CgmesCaseDataSourceClient.java
+++ b/src/main/java/com/powsybl/network/conversion/server/CgmesCaseDataSourceClient.java
@@ -26,8 +26,8 @@ import java.util.UUID;
 public class CgmesCaseDataSourceClient extends CaseDataSourceClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(CgmesCaseDataSourceClient.class);
 
-    public static final String TPBD_FILE_REGEX = "^([^(__)]*?(__ENTSOE_TPBD_).*(\\.xml))$";
-    public static final String EQBD_FILE_REGEX = "^([^(__)]*?(__ENTSOE_EQBD_).*(\\.xml))$";
+    public static final String TPBD_FILE_REGEX = "^(([^_][^_])*?(__ENTSOE_TPBD_).*(\\.xml))$";
+    public static final String EQBD_FILE_REGEX = "^(([^_][^_])*?(__ENTSOE_EQBD_).*(\\.xml))$";
 
     private List<BoundaryInfos> boundaries;
 

--- a/src/main/java/com/powsybl/network/conversion/server/CgmesCaseDataSourceClient.java
+++ b/src/main/java/com/powsybl/network/conversion/server/CgmesCaseDataSourceClient.java
@@ -26,8 +26,8 @@ import java.util.UUID;
 public class CgmesCaseDataSourceClient extends CaseDataSourceClient {
     private static final Logger LOGGER = LoggerFactory.getLogger(CgmesCaseDataSourceClient.class);
 
-    public static final String TPBD_FILE_REGEX = "^(.*?(__ENTSOE_TPBD_).*(\\.xml))$";
-    public static final String EQBD_FILE_REGEX = "^(.*?(__ENTSOE_EQBD_).*(\\.xml))$";
+    public static final String TPBD_FILE_REGEX = "^([^(__)]*?(__ENTSOE_TPBD_).*(\\.xml))$";
+    public static final String EQBD_FILE_REGEX = "^([^(__)]*?(__ENTSOE_EQBD_).*(\\.xml))$";
 
     private List<BoundaryInfos> boundaries;
 

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionController.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionController.java
@@ -96,7 +96,7 @@ public class NetworkConversionController {
     public ResponseEntity<NetworkInfos> importCgmesCase(@RequestParam("caseUuid") UUID caseUuid,
                                                         @RequestBody(required = false) List<BoundaryInfos> boundaries) {
         LOGGER.debug("Importing cgmes case {}...", caseUuid);
-        NetworkInfos networkInfos = networkConversionService.importCgmesCase(caseUuid, boundaries);
+        var networkInfos = networkConversionService.importCgmesCase(caseUuid, boundaries);
         return ResponseEntity.ok().body(networkInfos);
     }
 }

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionController.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionController.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.network.conversion.server;
 
+import com.powsybl.network.conversion.server.dto.BoundaryInfos;
 import com.powsybl.network.conversion.server.dto.ExportNetworkInfos;
 import com.powsybl.network.conversion.server.dto.NetworkInfos;
 import io.swagger.annotations.Api;
@@ -32,6 +33,7 @@ import java.util.stream.Collectors;
 
 /**
  * @author Abdelsalem Hedhili <abdelsalem.hedhili at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 
 @RestController
@@ -89,4 +91,12 @@ public class NetworkConversionController {
         return ResponseEntity.ok().headers(header).contentType(MediaType.APPLICATION_OCTET_STREAM).body(exportNetworkInfos.getNetworkData());
     }
 
+    @PostMapping(value = "/networks/cgmes")
+    @ApiOperation(value = "Import a cgmes case into the store, using provided boundaries")
+    public ResponseEntity<NetworkInfos> importCgmesCase(@RequestParam("caseUuid") UUID caseUuid,
+                                                        @RequestBody(required = false) List<BoundaryInfos> boundaries) {
+        LOGGER.debug("Importing cgmes case {}...", caseUuid);
+        NetworkInfos networkInfos = networkConversionService.importCgmesCase(caseUuid, boundaries);
+        return ResponseEntity.ok().body(networkInfos);
+    }
 }

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -175,8 +175,8 @@ public class NetworkConversionService {
             return importCase(caseUuid);
         } else {  // import using the given boundaries
             CaseDataSourceClient dataSource = new CgmesCaseDataSourceClient(caseServerRest, caseUuid, boundaries);
-            Network network = networkStoreService.importNetwork(dataSource);
-            UUID networkUuid = networkStoreService.getNetworkUuid(network);
+            var network = networkStoreService.importNetwork(dataSource);
+            var networkUuid = networkStoreService.getNetworkUuid(network);
             return new NetworkInfos(networkUuid, network.getId());
         }
     }

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -15,10 +15,12 @@ import com.powsybl.commons.xml.XmlUtil;
 import com.powsybl.iidm.export.Exporters;
 import com.powsybl.iidm.mergingview.MergingView;
 import com.powsybl.iidm.network.Network;
+import com.powsybl.network.conversion.server.dto.BoundaryInfos;
 import com.powsybl.network.conversion.server.dto.ExportNetworkInfos;
 import com.powsybl.network.conversion.server.dto.NetworkInfos;
 import com.powsybl.network.store.client.NetworkStoreService;
 import com.powsybl.network.store.client.PreloadingStrategy;
+import org.apache.commons.collections4.CollectionUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +43,7 @@ import java.util.zip.ZipOutputStream;
 
 /**
  * @author Abdelsalem Hedhili <abdelsalem.hedhili at rte-france.com>
+ * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
 
 @Service
@@ -165,5 +168,16 @@ public class NetworkConversionService {
             }
         }
         return new ExportNetworkInfos(network.getNameOrId(), outputStream.toByteArray());
+    }
+
+    NetworkInfos importCgmesCase(UUID caseUuid, List<BoundaryInfos> boundaries) {
+        if (CollectionUtils.isEmpty(boundaries)) {  // no boundaries given, standard import
+            return importCase(caseUuid);
+        } else {  // import using the given boundaries
+            CaseDataSourceClient dataSource = new CgmesCaseDataSourceClient(caseServerRest, caseUuid, boundaries);
+            Network network = networkStoreService.importNetwork(dataSource);
+            UUID networkUuid = networkStoreService.getNetworkUuid(network);
+            return new NetworkInfos(networkUuid, network.getId());
+        }
     }
 }

--- a/src/main/java/com/powsybl/network/conversion/server/dto/BoundaryInfos.java
+++ b/src/main/java/com/powsybl/network/conversion/server/dto/BoundaryInfos.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2019, RTE (http://www.rte-france.com)
+ * Copyright (c) 2021, RTE (http://www.rte-france.com)
  * This Source Code Form is subject to the terms of the Mozilla Public
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/.
@@ -10,17 +10,18 @@ import io.swagger.annotations.ApiModel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import java.util.UUID;
-
 /**
- * @author Abdelsalem Hedhili <abdelsalem.hedhili at rte-france.com>
  * @author Franck Lecuyer <franck.lecuyer at rte-france.com>
  */
+
 @AllArgsConstructor
 @Getter
-@ApiModel("Network attributes")
-public class NetworkInfos {
-    private UUID networkUuid;
+@ApiModel("Boundary attributes")
+public class BoundaryInfos {
 
-    private String networkId;
+    private String id;
+
+    private String filename;
+
+    private String boundary;
 }

--- a/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
+++ b/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
@@ -9,6 +9,7 @@ package com.powsybl.network.conversion.server;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.powsybl.cgmes.conformity.test.CgmesConformity1Catalog;
 import com.powsybl.cgmes.conversion.CgmesImport;
+import com.powsybl.commons.PowsyblException;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.datasource.ResourceDataSource;
 import com.powsybl.commons.datasource.ResourceSet;
@@ -46,6 +47,7 @@ import java.util.UUID;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -196,6 +198,9 @@ public class NetworkConversionTest {
 
         input = client.newInputStream("20210326T0000Z__ENTSOE_TPBD_6.xml");
         assertArrayEquals(tpbdContent.getBytes(StandardCharsets.UTF_8), org.apache.commons.io.IOUtils.toByteArray(input));
+
+        final CgmesCaseDataSourceClient client2 = new CgmesCaseDataSourceClient(caseServerRest, caseUuid, Collections.emptyList());
+        assertThrows(PowsyblException.class, () -> client2.newInputStream("20210326T0000Z__ENTSOE_EQBD_101.xml"));
     }
 
     @Test

--- a/src/test/resources/20210326T0930Z_1D_BE_SSH_6.xml
+++ b/src/test/resources/20210326T0930Z_1D_BE_SSH_6.xml
@@ -1,0 +1,307 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:cim="http://iec.ch/TC57/2013/CIM-schema-cim16#" xmlns:entsoe="http://entsoe.eu/CIM/SchemaExtension/3/1#" xmlns:md="http://iec.ch/TC57/61970-552/ModelDescription/1#">
+  <md:FullModel rdf:about="urn:uuid:75271ec4-af11-4a87-8137-d6d2b43b594d">
+    <md:Model.created>2014-10-24T16:53:10</md:Model.created>
+    <md:Model.scenarioTime>2017-10-02T09:30:00Z</md:Model.scenarioTime>
+    <md:Model.version>6</md:Model.version>
+    <md:Model.DependentOn rdf:resource="urn:uuid:96adadbe-902b-4cd6-9fc8-01a56ecbee79"/>
+    <md:Model.description>CGMES Conformity Assessment: MicroGridTestConfiguration T4 BB (MAS BE). The model is owned by ENTSO-E and is provided by ENTSO-E “as it is”. To the fullest extent permitted by law, ENTSO-E shall not be liable for any damages of any kind arising out of the use of the model (including any of its subsequent modifications). ENTSO-E neither warrants, nor represents that the use of the model will not infringe the rights of third parties. Any use of the model shall  include a reference to ENTSO-E. ENTSO-E web site is the only official source of information related to the model.</md:Model.description>
+    <md:Model.modelingAuthoritySet>http://elia.be/CAS2.0/MicroGridTestConfiguration</md:Model.modelingAuthoritySet>
+    <md:Model.profile>http://entsoe.eu/CIM/SteadyStateHypothesis/1/1</md:Model.profile>
+    <md:Model.Supersedes rdf:resource="urn:uuid:52b712d1-f3b0-4a59-9191-79f2fb1e4c4e"/>
+  </md:FullModel>
+  <cim:Terminal rdf:about="#_57ae9251-c022-4c67-a8eb-611ad54c963c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_5b2c65b0-68ce-4530-85b7-385346a3b5e1">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_699545b9-82b9-4331-bc80-538d73b4ba56">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_77f04391-aa23-49b6-b3e9-6089130bb5d5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_231a4cf8-5069-4d53-96e4-e839f073f1ea">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f3b56334-4638-49d3-a6a0-3f417422b8f5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c14d2036-72ec-4df3-b1b7-75d8afd9a1fe">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_f9f29835-8a31-4310-9780-b1ad26f3cbb0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_051d49ba-4360-4372-86bf-50eb8cf29778">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_02a244ca-8bcb-4e25-8613-e948b8ba1f22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_05a17350-55f5-4a00-9a50-8c0048a25495">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a4d42d33-ae54-4fe9-ad59-f30da0dfb809">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1ef0715a-d5a9-477b-b6e7-b635529ac140">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_70d962fb-a492-4c36-8cad-b5c584df53bd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca7974cf-b25e-4898-9221-7154233e5eb2">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_1182d878-2eaa-4eec-91be-ce7b2b1e7f9a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4c19ace6-c825-4c5b-87d9-031e6e6a3379">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ab7ece75-d726-48c8-a924-b0a9325e6d51">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c3774d3f-f48c-4954-a0cf-b4572eb714fd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_2cd21c77-b8b1-4896-95fb-240f45b9ac89">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_76e9ca77-f805-40ea-8120-5a6d58416d34">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53fd6693-57e6-482e-8fbe-dcf3531a7ce0">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ca0f7e2e-3442-4ada-a704-91f319c0ebe3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4bb5407b-b4a5-416c-80ad-1a778ada2b9b">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_beffa353-7d10-421d-9c08-036b744b1cee">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_22af3121-1a66-4546-bd80-4371f417c644">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d5e2e58e-ccf6-47d9-b3bb-3088eb7a9b6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9539c41-d114-4280-8a54-8ecec398091e">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_53072f42-f77b-47e2-bd9a-e097c910b173">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_c41978db-794b-4bae-953e-60fc519e87dd">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_d238885e-d9b6-4edc-8567-6a68c605ed67">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_4a7363a4-0b21-4f65-8bba-33e3a8f6bac3">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_b9376bea-c75d-49f3-94ca-6a71fa0086a5">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a036b765-1669-4f64-acd3-1e8fbd513312">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_cbdf1842-74ed-4fce-a5d4-0296c82cbc92">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_67bb74f1-8620-4a32-9d7d-a44092d11d22">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8171fc34-6891-40e0-92d1-da9f4ba69e26">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_13dcec71-4b02-4c0c-93a7-8e16db4aa0b7">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_3c6d83a3-b5f9-41a2-a3d9-cf15d903ed0a">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_ad794c0e-b9ec-420b-ada1-97680e3dde05">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_fa9e0f4d-8a2f-45e1-9e36-3611600d1c94">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_800ada75-8c8c-4568-aec5-20f799e45f3c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_62fc0a4e-00aa-4bf7-b1a0-3a5b2c0b5492">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_65b8c937-9b25-4b9e-addf-602dbc1337f9">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_a1b46f53-86f1-497e-bf57-c3b6268bcd6c">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_8f1c492f-a7cc-4160-9a14-54f1743e4850">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:Terminal rdf:about="#_302fe23a-f64d-41bd-8a81-78130433916d">
+    <cim:ACDCTerminal.connected>true</cim:ACDCTerminal.connected>
+  </cim:Terminal>
+  <cim:EnergyConsumer rdf:about="#_b1480a00-b427-4001-a26c-51954d2bb7e9">
+    <cim:EnergyConsumer.p>1.000000</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>0e+000</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_1c6beed6-1acf-42e7-ba55-0cc9f04bddd8">
+    <cim:EnergyConsumer.p>200.000000</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>50.000000</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:EnergyConsumer rdf:about="#_cb459405-cc14-4215-a45c-416789205904">
+    <cim:EnergyConsumer.p>200.000000</cim:EnergyConsumer.p>
+    <cim:EnergyConsumer.q>90.000000</cim:EnergyConsumer.q>
+  </cim:EnergyConsumer>
+  <cim:GeneratingUnit rdf:about="#_5b7a4d43-09ec-4033-882d-64a76d557631">
+    <cim:GeneratingUnit.normalPF>0e+000</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_550ebe0d-f2b2-48c1-991f-cebea43a21aa">
+    <cim:RotatingMachine.p>-118.000000</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-18.720301</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator"/>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+  </cim:SynchronousMachine>
+  <cim:GeneratingUnit rdf:about="#_18993b11-2966-4bce-bab9-d86103f83b53">
+    <cim:GeneratingUnit.normalPF>0e+000</cim:GeneratingUnit.normalPF>
+  </cim:GeneratingUnit>
+  <cim:SynchronousMachine rdf:about="#_3a3b27be-b18b-4385-b557-6735d733baf0">
+    <cim:RotatingMachine.p>-90.000000</cim:RotatingMachine.p>
+    <cim:RotatingMachine.q>-100.256000</cim:RotatingMachine.q>
+    <cim:SynchronousMachine.operatingMode rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#SynchronousMachineOperatingMode.generator"/>
+    <cim:SynchronousMachine.referencePriority>0</cim:SynchronousMachine.referencePriority>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+  </cim:SynchronousMachine>
+  <cim:RatioTapChanger rdf:about="#_83cc66dd-8d93-4a2c-8103-f1f5a9cf7e2e">
+    <cim:TapChanger.step>14</cim:TapChanger.step>
+    <cim:TapChanger.controlEnabled>true</cim:TapChanger.controlEnabled>
+  </cim:RatioTapChanger>
+  <cim:PhaseTapChangerAsymmetrical rdf:about="#_36b83adb-3d45-4693-8967-96627b5f9ec9">
+    <cim:TapChanger.step>10</cim:TapChanger.step>
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+  </cim:PhaseTapChangerAsymmetrical>
+  <cim:PhaseTapChangerSymmetrical rdf:about="#_63454a73-f439-45bb-951a-e7b193986571">
+    <cim:TapChanger.step>10</cim:TapChanger.step>
+    <cim:TapChanger.controlEnabled>true</cim:TapChanger.controlEnabled>
+  </cim:PhaseTapChangerSymmetrical>
+  <cim:RatioTapChanger rdf:about="#_fe25f43a-7341-446e-a71a-8ab7119ba806">
+    <cim:TapChanger.step>17</cim:TapChanger.step>
+    <cim:TapChanger.controlEnabled>false</cim:TapChanger.controlEnabled>
+  </cim:RatioTapChanger>
+  <cim:StaticVarCompensator rdf:about="#_3c69652c-ff14-4550-9a87-b6fdaccbb5f4">
+    <cim:StaticVarCompensator.q>0e+000</cim:StaticVarCompensator.q>
+    <cim:RegulatingCondEq.controlEnabled>true</cim:RegulatingCondEq.controlEnabled>
+  </cim:StaticVarCompensator>
+  <cim:NonlinearShuntCompensator rdf:about="#_002b0a40-3957-46db-b84a-30420083558f">
+    <cim:ShuntCompensator.sections>1</cim:ShuntCompensator.sections>
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+  </cim:NonlinearShuntCompensator>
+  <cim:LinearShuntCompensator rdf:about="#_d771118f-36e9-4115-a128-cc3d9ce3e3da">
+    <cim:ShuntCompensator.sections>1</cim:ShuntCompensator.sections>
+    <cim:RegulatingCondEq.controlEnabled>false</cim:RegulatingCondEq.controlEnabled>
+  </cim:LinearShuntCompensator>
+  <cim:EquivalentInjection rdf:about="#_6f014d4c-c1b0-4eed-8d6d-bae3bc87afcf">
+    <cim:EquivalentInjection.p>-24.647174</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>120.204607</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_24413233-26c3-4f7e-9f72-4461796938be">
+    <cim:EquivalentInjection.p>-12.823174</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>63.626944</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_14b352cb-5574-40c5-bf83-0ed3574554a3">
+    <cim:EquivalentInjection.p>-7.631551</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>66.838069</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_87ea56f3-962a-427a-85d6-13b1f9295174">
+    <cim:EquivalentInjection.p>-85.058722</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>0.789714</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:EquivalentInjection rdf:about="#_f7f61a91-eca2-4492-8bd7-9ec2b28fc837">
+    <cim:EquivalentInjection.p>-106.135567</cim:EquivalentInjection.p>
+    <cim:EquivalentInjection.q>10.745724</cim:EquivalentInjection.q>
+    <cim:EquivalentInjection.regulationStatus>false</cim:EquivalentInjection.regulationStatus>
+    <cim:EquivalentInjection.regulationTarget>0.0</cim:EquivalentInjection.regulationTarget>
+  </cim:EquivalentInjection>
+  <cim:TapChangerControl rdf:about="#_97110e84-7da6-479c-846c-696fdaa83d56">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>10.815000</cim:RegulatingControl.targetValue>
+  </cim:TapChangerControl>
+  <cim:TapChangerControl rdf:about="#_77a5948c-3782-455d-aea1-20b062489b65">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.M"/>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>0e+000</cim:RegulatingControl.targetValue>
+  </cim:TapChangerControl>
+  <cim:TapChangerControl rdf:about="#_f43499bf-6bf3-483d-ae2a-e46d696a66b2">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>35.00000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.M"/>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>-65.000000</cim:RegulatingControl.targetValue>
+  </cim:TapChangerControl>
+  <cim:TapChangerControl rdf:about="#_38f972bc-b7fd-4e75-8c24-379a86fbb506">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>0e+000</cim:RegulatingControl.targetValue>
+  </cim:TapChangerControl>
+  <cim:RegulatingControl rdf:about="#_84bf5be8-eb59-4555-b131-fce4d2d7775d">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>21.987000</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:about="#_6ba406ce-78cf-4485-9b01-a34e584f1a8d">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>115.500000</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:about="#_bee06911-8d5c-44c4-b2d2-5c22a461b5a0">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>380.000000</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:about="#_4d50f86d-0d12-4ca3-9430-56bb05f9eee6">
+    <cim:RegulatingControl.discrete>true</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>false</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>110.000000</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+  <cim:RegulatingControl rdf:about="#_caf65447-3cfb-48d7-aaaa-cd9af3d34261">
+    <cim:RegulatingControl.discrete>false</cim:RegulatingControl.discrete>
+    <cim:RegulatingControl.targetDeadband>0.500000</cim:RegulatingControl.targetDeadband>
+    <cim:RegulatingControl.targetValueUnitMultiplier rdf:resource="http://iec.ch/TC57/2013/CIM-schema-cim16#UnitMultiplier.k"/>
+    <cim:RegulatingControl.enabled>true</cim:RegulatingControl.enabled>
+    <cim:RegulatingControl.targetValue>229.500000</cim:RegulatingControl.targetValue>
+  </cim:RegulatingControl>
+</rdf:RDF>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The import of a cgmes case in the network store can't use specific provided boundaries


**What is the new behavior (if this is a feature change)?**
The import of a cgmes case in the network store can now use specific provided boundaries (this is used in the merge orchestrator, when importing the cases, using the last boundaries available)



**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
