### PR TITLE
Create empty reporter if no report after import

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -97,9 +97,7 @@ public class NetworkConversionService {
         ReporterModel reporter = new ReporterModel("importNetwork", "import network");
         Network network = networkStoreService.importNetwork(dataSource, reporter);
         UUID networkUuid = networkStoreService.getNetworkUuid(network);
-        if (!reporter.getReports().isEmpty() || !reporter.getSubReporters().isEmpty()) {
-            sendReport(networkUuid, reporter);
-        }
+        sendReport(networkUuid, reporter);
         return new NetworkInfos(networkUuid, network.getId());
     }
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
When we create a network by importing a case if the importer do not create reports no reporter is created in the database


**What is the new behavior (if this is a feature change)?**
When we create a network by importing a case if the importer do not create reports a empty reporter is created in the database

