### PR TITLE
Add a configurable elasticsearch client timeout

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/elasticsearch/ESConfig.java
+++ b/src/main/java/com/powsybl/network/conversion/server/elasticsearch/ESConfig.java
@@ -36,6 +36,9 @@ public class ESConfig extends AbstractElasticsearchConfiguration {
     @Value("#{'${spring.data.elasticsearch.embedded:false}' ? '${spring.data.elasticsearch.embedded.port:}' : '${spring.data.elasticsearch.port}'}")
     private int esPort;
 
+    @Value("${spring.data.elasticsearch.client.timeout:60}")
+    int timeout;
+
     @Bean
     @ConditionalOnExpression("'${spring.data.elasticsearch.enabled:false}' == 'true'")
     public EquipmentInfosService studyInfosServiceImpl(EquipmentInfosRepository equipmentInfosRepository) {
@@ -53,8 +56,9 @@ public class ESConfig extends AbstractElasticsearchConfiguration {
     @SuppressWarnings("squid:S2095")
     public RestHighLevelClient elasticsearchClient() {
         ClientConfiguration clientConfiguration = ClientConfiguration.builder()
-                .connectedTo(InetSocketAddress.createUnresolved(esHost, esPort))
-                .build();
+            .connectedTo(InetSocketAddress.createUnresolved(esHost, esPort))
+            .withConnectTimeout(timeout * 1000L).withSocketTimeout(timeout * 1000L)
+            .build();
 
         return RestClients.create(clientConfiguration).rest();
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,8 @@ spring:
       host: localhost
       port: 9200
       partition-size : 10000
+      client:
+        timeout : 60  # Seconds
 
 network-store-server:
   preloading-strategy: COLLECTION


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
The timeout of the elasticsearch has 5 seconds as default value.
It's too limited to index a large network and if the indexing fails then the import also fails
`org.springframework.dao.DataAccessResourceFailureException: 5,000 milliseconds timeout on connection http-outgoing-2 [ACTIVE]; nested exception is java.lang.RuntimeException: 5,000 milliseconds timeout on connection http-outgoing-2`

**What is the new behavior (if this is a feature change)?**
The timeout is now configurable with 60 seconds as default value

