### PR TITLE
Store voltage level name in elasticsearch

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -113,7 +113,7 @@ public class NetworkConversionService {
             .id(i.getId())
             .name(i.getNameOrId())
             .type(EquipmentType.getType(i).name())
-            .voltageLevelsIds(EquipmentInfos.getVoltageLevelsIds(i))
+            .voltageLevels(EquipmentInfos.getVoltageLevels(i))
             .build();
     }
 

--- a/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
+++ b/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
@@ -73,7 +73,7 @@ public class EquipmentInfos {
                     new VoltageLevelInfos(branch.getTerminal1().getVoltageLevel().getId(), branch.getTerminal1().getVoltageLevel().getNameOrId()),
                     new VoltageLevelInfos(branch.getTerminal2().getVoltageLevel().getId(), branch.getTerminal2().getVoltageLevel().getNameOrId())
             )
-            .collect(Collectors.toSet()); // Internal line
+            .collect(Collectors.toSet());
         } else if (identifiable instanceof ThreeWindingsTransformer) {
             ThreeWindingsTransformer w3t = (ThreeWindingsTransformer) identifiable;
             return Stream.of(

--- a/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
+++ b/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
@@ -51,34 +51,34 @@ public class EquipmentInfos {
 
     public static Set<VoltageLevelInfos> getVoltageLevels(@NonNull Identifiable<?> identifiable) {
         if (identifiable instanceof Substation) {
-            return ((Substation) identifiable).getVoltageLevelStream().map(vl -> new VoltageLevelInfos(vl.getId(), vl.getNameOrId())).collect(Collectors.toSet());
+            return ((Substation) identifiable).getVoltageLevelStream().map(vl -> VoltageLevelInfos.builder().id(vl.getId()).name(vl.getNameOrId()).build()).collect(Collectors.toSet());
         } else if (identifiable instanceof VoltageLevel) {
-            return Set.of(new VoltageLevelInfos(identifiable.getId(), identifiable.getNameOrId()));
+            return Set.of(VoltageLevelInfos.builder().id(identifiable.getId()).name(identifiable.getNameOrId()).build());
         } else if (identifiable instanceof Switch) {
-            return Set.of(new VoltageLevelInfos(((Switch) identifiable).getVoltageLevel().getId(), ((Switch) identifiable).getVoltageLevel().getNameOrId()));
+            return Set.of(VoltageLevelInfos.builder().id(((Switch) identifiable).getVoltageLevel().getId()).name(((Switch) identifiable).getVoltageLevel().getNameOrId()).build());
         } else if (identifiable instanceof Injection) {
-            return Set.of(new VoltageLevelInfos(((Injection<?>) identifiable).getTerminal().getVoltageLevel().getId(), ((Injection<?>) identifiable).getTerminal().getVoltageLevel().getNameOrId()));
+            return Set.of(VoltageLevelInfos.builder().id(((Injection<?>) identifiable).getTerminal().getVoltageLevel().getId()).name(((Injection<?>) identifiable).getTerminal().getVoltageLevel().getNameOrId()).build());
         } else if (identifiable instanceof Bus) {
-            return Set.of(new VoltageLevelInfos(((Bus) identifiable).getVoltageLevel().getId(), ((Bus) identifiable).getVoltageLevel().getNameOrId()));
+            return Set.of(VoltageLevelInfos.builder().id(((Bus) identifiable).getVoltageLevel().getId()).name(((Bus) identifiable).getVoltageLevel().getNameOrId()).build());
         } else if (identifiable instanceof HvdcLine) {
             HvdcLine hvdcLine = (HvdcLine) identifiable;
             return Set.of(
-                new VoltageLevelInfos(hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getId(), hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getNameOrId()),
-                new VoltageLevelInfos(hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getId(), hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getNameOrId())
+                VoltageLevelInfos.builder().id(hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getId()).name(hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getNameOrId()).build(),
+                VoltageLevelInfos.builder().id(hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getId()).name(hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getNameOrId()).build()
             );
         } else if (identifiable instanceof Branch) {
             Branch<?> branch = (Branch<?>) identifiable;
             return Stream.of(
-                    new VoltageLevelInfos(branch.getTerminal1().getVoltageLevel().getId(), branch.getTerminal1().getVoltageLevel().getNameOrId()),
-                    new VoltageLevelInfos(branch.getTerminal2().getVoltageLevel().getId(), branch.getTerminal2().getVoltageLevel().getNameOrId())
+                     VoltageLevelInfos.builder().id(branch.getTerminal1().getVoltageLevel().getId()).name(branch.getTerminal1().getVoltageLevel().getNameOrId()).build(),
+                     VoltageLevelInfos.builder().id(branch.getTerminal2().getVoltageLevel().getId()).name(branch.getTerminal2().getVoltageLevel().getNameOrId()).build()
                 )
                 .collect(Collectors.toSet());
         } else if (identifiable instanceof ThreeWindingsTransformer) {
             ThreeWindingsTransformer w3t = (ThreeWindingsTransformer) identifiable;
             return Stream.of(
-                    new VoltageLevelInfos(w3t.getTerminal(ThreeWindingsTransformer.Side.ONE).getVoltageLevel().getId(), w3t.getTerminal(ThreeWindingsTransformer.Side.ONE).getVoltageLevel().getNameOrId()),
-                    new VoltageLevelInfos(w3t.getTerminal(ThreeWindingsTransformer.Side.TWO).getVoltageLevel().getId(), w3t.getTerminal(ThreeWindingsTransformer.Side.TWO).getVoltageLevel().getNameOrId()),
-                    new VoltageLevelInfos(w3t.getTerminal(ThreeWindingsTransformer.Side.THREE).getVoltageLevel().getId(), w3t.getTerminal(ThreeWindingsTransformer.Side.THREE).getVoltageLevel().getNameOrId())
+                    VoltageLevelInfos.builder().id(w3t.getTerminal(ThreeWindingsTransformer.Side.ONE).getVoltageLevel().getId()).name(w3t.getTerminal(ThreeWindingsTransformer.Side.ONE).getVoltageLevel().getNameOrId()).build(),
+                    VoltageLevelInfos.builder().id(w3t.getTerminal(ThreeWindingsTransformer.Side.TWO).getVoltageLevel().getId()).name(w3t.getTerminal(ThreeWindingsTransformer.Side.TWO).getVoltageLevel().getNameOrId()).build(),
+                    VoltageLevelInfos.builder().id(w3t.getTerminal(ThreeWindingsTransformer.Side.THREE).getVoltageLevel().getId()).name(w3t.getTerminal(ThreeWindingsTransformer.Side.THREE).getVoltageLevel().getNameOrId()).build()
                 )
                 .collect(Collectors.toSet());
         }

--- a/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
+++ b/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
@@ -17,6 +17,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
 
 import java.util.Set;
 import java.util.UUID;
@@ -46,40 +47,41 @@ public class EquipmentInfos {
     @Field("equipmentType")
     String type;
 
-    Set<String> voltageLevelsIds;
+    @Field(type = FieldType.Nested, includeInParent = true)
+    Set<VoltageLevelInfos> voltageLevels;
 
     UUID networkUuid;
 
-    public static Set<String> getVoltageLevelsIds(Identifiable<?> identifiable) {
+    public static Set<VoltageLevelInfos> getVoltageLevels(Identifiable<?> identifiable) {
         if (identifiable instanceof Substation) {
-            return ((Substation) identifiable).getVoltageLevelStream().map(VoltageLevel::getId).collect(Collectors.toSet());
+            return ((Substation) identifiable).getVoltageLevelStream().map(vl -> new VoltageLevelInfos(vl.getId(), vl.getNameOrId())).collect(Collectors.toSet());
         } else if (identifiable instanceof VoltageLevel) {
-            return Set.of(identifiable.getId());
+            return Set.of(new VoltageLevelInfos(identifiable.getId(), identifiable.getNameOrId()));
         } else if (identifiable instanceof Switch) {
-            return Set.of(((Switch) identifiable).getVoltageLevel().getId());
+            return Set.of(new VoltageLevelInfos(((Switch) identifiable).getVoltageLevel().getId(), ((Switch) identifiable).getVoltageLevel().getNameOrId()));
         } else if (identifiable instanceof Injection) {
-            return Set.of(((Injection<?>) identifiable).getTerminal().getVoltageLevel().getId());
+            return Set.of(new VoltageLevelInfos(((Injection<?>) identifiable).getTerminal().getVoltageLevel().getId(), ((Injection<?>) identifiable).getTerminal().getVoltageLevel().getNameOrId()));
         } else if (identifiable instanceof HvdcLine) {
             HvdcLine hvdcLine = (HvdcLine) identifiable;
             return Set.of(
-                hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getId(),
-                hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getId()
+                new VoltageLevelInfos(hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getId(), hvdcLine.getConverterStation1().getTerminal().getVoltageLevel().getNameOrId()),
+                new VoltageLevelInfos(hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getId(), hvdcLine.getConverterStation2().getTerminal().getVoltageLevel().getNameOrId())
             );
         } else if (identifiable instanceof Branch) {
             Branch<?> branch = (Branch<?>) identifiable;
             return Stream.of(
-                    branch.getTerminal1().getVoltageLevel().getId(),
-                    branch.getTerminal2().getVoltageLevel().getId()
-                )
-                .collect(Collectors.toSet());
+                    new VoltageLevelInfos(branch.getTerminal1().getVoltageLevel().getId(), branch.getTerminal1().getVoltageLevel().getNameOrId()),
+                    new VoltageLevelInfos(branch.getTerminal2().getVoltageLevel().getId(), branch.getTerminal2().getVoltageLevel().getNameOrId())
+            )
+            .collect(Collectors.toSet()); // Internal line
         } else if (identifiable instanceof ThreeWindingsTransformer) {
             ThreeWindingsTransformer w3t = (ThreeWindingsTransformer) identifiable;
             return Stream.of(
-                    w3t.getTerminal(ThreeWindingsTransformer.Side.ONE).getVoltageLevel().getId(),
-                    w3t.getTerminal(ThreeWindingsTransformer.Side.TWO).getVoltageLevel().getId(),
-                    w3t.getTerminal(ThreeWindingsTransformer.Side.THREE).getVoltageLevel().getId()
-                )
-                .collect(Collectors.toSet());
+                new VoltageLevelInfos(w3t.getTerminal(ThreeWindingsTransformer.Side.ONE).getVoltageLevel().getId(), w3t.getTerminal(ThreeWindingsTransformer.Side.ONE).getVoltageLevel().getNameOrId()),
+                new VoltageLevelInfos(w3t.getTerminal(ThreeWindingsTransformer.Side.TWO).getVoltageLevel().getId(), w3t.getTerminal(ThreeWindingsTransformer.Side.TWO).getVoltageLevel().getNameOrId()),
+                new VoltageLevelInfos(w3t.getTerminal(ThreeWindingsTransformer.Side.THREE).getVoltageLevel().getId(), w3t.getTerminal(ThreeWindingsTransformer.Side.THREE).getVoltageLevel().getNameOrId())
+            )
+            .collect(Collectors.toSet());
         }
 
         throw NetworkConversionException.createEquipmentTypeUnknown(identifiable.getClass().getSimpleName());

--- a/src/main/java/com/powsybl/network/conversion/server/dto/VoltageLevelInfos.java
+++ b/src/main/java/com/powsybl/network/conversion/server/dto/VoltageLevelInfos.java
@@ -6,7 +6,10 @@
  */
 package com.powsybl.network.conversion.server.dto;
 
-import lombok.*;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
 import lombok.experimental.SuperBuilder;
 
 /**
@@ -14,7 +17,6 @@ import lombok.experimental.SuperBuilder;
  */
 @SuperBuilder
 @NoArgsConstructor
-@AllArgsConstructor
 @Getter
 @ToString
 @EqualsAndHashCode

--- a/src/main/java/com/powsybl/network/conversion/server/dto/VoltageLevelInfos.java
+++ b/src/main/java/com/powsybl/network/conversion/server/dto/VoltageLevelInfos.java
@@ -1,0 +1,26 @@
+/*
+  Copyright (c) 2021, RTE (http://www.rte-france.com)
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.conversion.server.dto;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+@SuperBuilder
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@ToString
+@EqualsAndHashCode
+public class VoltageLevelInfos {
+
+    String id;
+
+    String name;
+}

--- a/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceMockTests.java
+++ b/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceMockTests.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.network.conversion.server.dto.EquipmentInfos;
 import com.powsybl.network.conversion.server.dto.EquipmentType;
+import com.powsybl.network.conversion.server.dto.VoltageLevelInfos;
 import com.powsybl.network.conversion.server.elasticsearch.EquipmentInfosService;
 import com.powsybl.network.store.iidm.impl.NetworkFactoryImpl;
 import com.powsybl.network.store.iidm.impl.NetworkImpl;
@@ -41,8 +42,8 @@ public class EquipmentInfosServiceMockTests {
     @Test
     public void testAddDeleteEquipmentInfos() {
         List<EquipmentInfos> infos = List.of(
-                EquipmentInfos.builder().networkUuid(NETWORK_UUID).id("id1").name("name1").type(EquipmentType.LOAD.name()).voltageLevelsIds(Set.of("vl1")).build(),
-                EquipmentInfos.builder().networkUuid(NETWORK_UUID).id("id1").name("name1").type(EquipmentType.LOAD.name()).voltageLevelsIds(Set.of("vl2")).build()
+                EquipmentInfos.builder().networkUuid(NETWORK_UUID).id("id1").name("name1").type(EquipmentType.LOAD.name()).voltageLevels(Set.of(VoltageLevelInfos.builder().id("vl1").name("vl1").build())).build(),
+                EquipmentInfos.builder().networkUuid(NETWORK_UUID).id("id1").name("name1").type(EquipmentType.LOAD.name()).voltageLevels(Set.of(VoltageLevelInfos.builder().id("vl2").name("vl2").build())).build()
         );
 
         equipmentInfosService.addAll(infos);

--- a/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceTests.java
+++ b/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceTests.java
@@ -11,6 +11,7 @@ import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
 import com.powsybl.network.conversion.server.dto.EquipmentInfos;
 import com.powsybl.network.conversion.server.dto.EquipmentType;
+import com.powsybl.network.conversion.server.dto.VoltageLevelInfos;
 import com.powsybl.network.conversion.server.elasticsearch.EquipmentInfosService;
 import com.powsybl.network.store.iidm.impl.NetworkFactoryImpl;
 import com.powsybl.network.store.iidm.impl.NetworkImpl;
@@ -44,8 +45,8 @@ public class EquipmentInfosServiceTests {
         EqualsVerifier.simple().forClass(EquipmentInfos.class).verify();
 
         List<EquipmentInfos> infos = List.of(
-            EquipmentInfos.builder().networkUuid(NETWORK_UUID).id("id1").name("name1").type(EquipmentType.LOAD.name()).voltageLevelsIds(Set.of("vl1")).build(),
-            EquipmentInfos.builder().networkUuid(NETWORK_UUID).id("id1").name("name1").type(EquipmentType.LOAD.name()).voltageLevelsIds(Set.of("vl2")).build()
+            EquipmentInfos.builder().networkUuid(NETWORK_UUID).id("id1").name("name1").type(EquipmentType.LOAD.name()).voltageLevels(Set.of(VoltageLevelInfos.builder().id("vl1").name("vl1").build())).build(),
+            EquipmentInfos.builder().networkUuid(NETWORK_UUID).id("id1").name("name1").type(EquipmentType.LOAD.name()).voltageLevels(Set.of(VoltageLevelInfos.builder().id("vl2").name("vl2").build())).build()
         );
 
         equipmentInfosService.addAll(infos);
@@ -61,7 +62,7 @@ public class EquipmentInfosServiceTests {
         String errorMessage = assertThrows(NetworkConversionException.class, () -> EquipmentType.getType(network)).getMessage();
         assertTrue(errorMessage.contains(String.format("The equipment type : %s is unknown", NetworkImpl.class.getSimpleName())));
 
-        errorMessage = assertThrows(NetworkConversionException.class, () -> EquipmentInfos.getVoltageLevelsIds(network)).getMessage();
+        errorMessage = assertThrows(NetworkConversionException.class, () -> EquipmentInfos.getVoltageLevels(network)).getMessage();
         assertTrue(errorMessage.contains(String.format("The equipment type : %s is unknown", NetworkImpl.class.getSimpleName())));
     }
 }

--- a/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceTests.java
+++ b/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceTests.java
@@ -43,6 +43,7 @@ public class EquipmentInfosServiceTests {
     @Test
     public void testAddDeleteEquipmentInfos() {
         EqualsVerifier.simple().forClass(EquipmentInfos.class).verify();
+        EqualsVerifier.simple().forClass(VoltageLevelInfos.class).verify();
 
         List<EquipmentInfos> infos = List.of(
             EquipmentInfos.builder().networkUuid(NETWORK_UUID).id("id1").name("name1").type(EquipmentType.LOAD.name()).voltageLevels(Set.of(VoltageLevelInfos.builder().id("vl1").name("vl1").build())).build(),


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, only voltage level id is stored in Elasticsearch for an equipment


**What is the new behavior (if this is a feature change)?**
Voltage level id and name are now both stored in Elasticsearch for an equipment


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
