### PR TITLE
Use testcontainers elasticsearch for tests (NodeClientFactoryBean is deprecated)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,6 +36,7 @@
         <powsybl-network-store-client.version>1.0.0-SNAPSHOT</powsybl-network-store-client.version>
         <powsybl-case-datasource-client.version>1.0.0-SNAPSHOT</powsybl-case-datasource-client.version>
         <powsybl-ws-commons.version>1.0.0</powsybl-ws-commons.version>
+        <testcontainers.version>1.16.2</testcontainers.version>
     </properties>
 
     <build>
@@ -123,6 +124,12 @@
                 <groupId>com.powsybl</groupId>
                 <artifactId>powsybl-ws-commons</artifactId>
                 <version>${powsybl-ws-commons.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.testcontainers</groupId>
+                <artifactId>elasticsearch</artifactId>
+                <version>${testcontainers.version}</version>
+                <scope>test</scope>
             </dependency>
         </dependencies>
     </dependencyManagement>
@@ -257,6 +264,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+            <artifactId>elasticsearch</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/com/powsybl/network/conversion/server/EmbeddedElasticsearch.java
+++ b/src/test/java/com/powsybl/network/conversion/server/EmbeddedElasticsearch.java
@@ -1,73 +1,49 @@
-/**
- * Copyright (c) 2021, RTE (http://www.rte-france.com)
- * This Source Code Form is subject to the terms of the Mozilla Public
- * License, v. 2.0. If a copy of the MPL was not distributed with this
- * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+/*
+  Copyright (c) 2021, RTE (http://www.rte-france.com)
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
  */
 package com.powsybl.network.conversion.server;
 
-import org.elasticsearch.action.admin.cluster.node.info.NodeInfo;
-import org.elasticsearch.action.admin.cluster.node.info.NodesInfoRequestBuilder;
-import org.elasticsearch.action.admin.cluster.node.info.NodesInfoResponse;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.BoundTransportAddress;
-import org.elasticsearch.common.transport.TransportAddress;
-import org.elasticsearch.http.HttpInfo;
-import org.elasticsearch.index.reindex.ReindexPlugin;
-import org.elasticsearch.node.Node;
-import org.elasticsearch.node.NodeValidationException;
-import org.elasticsearch.transport.Netty4Plugin;
-import org.junit.rules.ExternalResource;
-import org.springframework.data.elasticsearch.client.NodeClientFactoryBean;
 import org.springframework.stereotype.Component;
+import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
-import java.util.List;
-import java.util.UUID;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
 
 /**
  * A class to launch an embedded DB elasticsearch
- *
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
 @Component
-public class EmbeddedElasticsearch extends ExternalResource {
+public class EmbeddedElasticsearch {
 
-    public EmbeddedElasticsearch() throws NodeValidationException {
-        String pathHome = "src/test/resources/test-home-dir";
-        String pathData = "target/elasticsearchTestData";
-        String clusterName = UUID.randomUUID().toString();
+    private static final String ES_DOCKER_IMAGE_NAME = "docker.elastic.co/elasticsearch/elasticsearch";
+    private static final String ES_DOCKER_IMAGE_VERSION = "7.9.3";
 
-        Node node = new NodeClientFactoryBean.TestNode(
-                Settings.builder()
-                        .put("transport.type", "netty4")
-                        .put("discovery.type", "single-node")
-                        .put("http.type", "netty4")
-                        .put("path.home", pathHome)
-                        .put("path.data", pathData)
-                        .put("cluster.name", clusterName)
-                        .put("node.max_local_storage_nodes", 100)
-                        // the following 3 settings are needed to avoid problems on big, but
-                        // almost full filesystems, see DATAES-741
-                        .put("cluster.routing.allocation.disk.watermark.low", "1gb")
-                        .put("cluster.routing.allocation.disk.watermark.high", "1gb")
-                        .put("cluster.routing.allocation.disk.watermark.flood_stage", "1gb")
-                        .build(),
-                List.of(Netty4Plugin.class, ReindexPlugin.class));
+    private static ElasticsearchContainer elasticsearchContainer;
 
-        node.start();
+    @PostConstruct
+    public void postConstruct() {
+        if (elasticsearchContainer != null) {
+            return;
+        }
 
-        publishNodePort(node);
+        elasticsearchContainer = new ElasticsearchContainer(String.format("%s:%s", ES_DOCKER_IMAGE_NAME, ES_DOCKER_IMAGE_VERSION));
+        elasticsearchContainer.start();
+
+        System.setProperty("spring.data.elasticsearch.embedded", Boolean.toString(true));
+        System.setProperty("spring.data.elasticsearch.embedded.port", Integer.toString(elasticsearchContainer.getMappedPort(9200)));
     }
 
-    private void publishNodePort(Node node) {
-        NodesInfoRequestBuilder nodesInfoRequestBuilder = node.client().admin().cluster().prepareNodesInfo();
-        NodesInfoResponse nodesInfoResponse = nodesInfoRequestBuilder.get();
-        List<NodeInfo> nodeInfos = nodesInfoResponse.getNodes();
-        NodeInfo nodeInfo = nodeInfos.get(0);
-        HttpInfo httpInfo = nodeInfo.getInfo(HttpInfo.class);
-        BoundTransportAddress boundTransportAddress = httpInfo.address();
-        TransportAddress transportAddress = boundTransportAddress.publishAddress();
-        System.setProperty("spring.data.elasticsearch.embedded", Boolean.toString(true));
-        System.setProperty("spring.data.elasticsearch.embedded.port", Integer.toString(transportAddress.getPort()));
+    @PreDestroy
+    private void preDestroy() {
+        if (elasticsearchContainer == null) {
+            return;
+        }
+
+        elasticsearchContainer.stop();
+        elasticsearchContainer = null;
     }
 }

--- a/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceTests.java
+++ b/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceTests.java
@@ -20,6 +20,7 @@ import com.powsybl.network.conversion.server.elasticsearch.EquipmentInfosService
 import com.powsybl.network.store.iidm.impl.NetworkFactoryImpl;
 import com.powsybl.network.store.iidm.impl.NetworkImpl;
 import nl.jqno.equalsverifier.EqualsVerifier;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -45,6 +46,11 @@ public class EquipmentInfosServiceTests {
 
     @Autowired
     private EquipmentInfosService equipmentInfosService;
+
+    @Before
+    public void setup() {
+        equipmentInfosService.deleteAll(NETWORK_UUID);
+    }
 
     @Test
     public void testAddDeleteEquipmentInfos() {


### PR DESCRIPTION
Signed-off-by: Slimane AMAR <slimane.amar@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No

**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug fix

**What is the current behavior?** *(You can also link to an open issue here)*
For elasticserarch integration tests, we use NodeClientFactoryBean ( embedded Node clients) but this is not supporting anymore


**What is the new behavior (if this is a feature change)?**
For elasticserarch integration tests, now we use `testcontainers` which launches a Docker container

