### PR TITLE
Set variant id to initial state in elasticsearch when loading network

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
+++ b/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
@@ -67,8 +67,6 @@ public class EquipmentInfos {
 
     String variantId;
 
-    Boolean tombstoned;
-
     public static Set<VoltageLevelInfos> getVoltageLevels(@NonNull Identifiable<?> identifiable) {
         if (identifiable instanceof Substation) {
             return ((Substation) identifiable).getVoltageLevelStream().map(vl -> VoltageLevelInfos.builder().id(vl.getId()).name(vl.getNameOrId()).build()).collect(Collectors.toSet());

--- a/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
+++ b/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
@@ -65,6 +65,10 @@ public class EquipmentInfos {
 
     UUID networkUuid;
 
+    String variantId;
+
+    Boolean tombstoned;
+
     public static Set<VoltageLevelInfos> getVoltageLevels(@NonNull Identifiable<?> identifiable) {
         if (identifiable instanceof Substation) {
             return ((Substation) identifiable).getVoltageLevelStream().map(vl -> VoltageLevelInfos.builder().id(vl.getId()).name(vl.getNameOrId()).build()).collect(Collectors.toSet());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Currently, when network is loaded, no information about its variant id is stored for equipments search in ElasticSearch


**What is the new behavior (if this is a feature change)?**
Now, when network is loaded, variant id is set to InitialState in ElasticSearch for equipments search


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
