### PR TITLE
Fix : run the  embedded elasticsearch only for the unit tests that need it

### DIFF
--- a/src/test/java/com/powsybl/network/conversion/server/EmbeddedElasticsearch.java
+++ b/src/test/java/com/powsybl/network/conversion/server/EmbeddedElasticsearch.java
@@ -6,6 +6,7 @@
  */
 package com.powsybl.network.conversion.server;
 
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 import org.testcontainers.elasticsearch.ElasticsearchContainer;
 
@@ -14,6 +15,7 @@ import javax.annotation.PreDestroy;
 
 /**
  * A class to launch an embedded DB elasticsearch
+ *
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
 @Component
@@ -24,9 +26,12 @@ public class EmbeddedElasticsearch {
 
     private static ElasticsearchContainer elasticsearchContainer;
 
+    @Value("${spring.data.elasticsearch.enabled:false}")
+    boolean elasticsearchEnabled;
+
     @PostConstruct
     public void postConstruct() {
-        if (elasticsearchContainer != null) {
+        if (elasticsearchContainer != null || !elasticsearchEnabled) {
             return;
         }
 

--- a/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
+++ b/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
@@ -31,7 +31,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.*;
-import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
@@ -64,8 +63,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 
 @RunWith(SpringRunner.class)
-@WebMvcTest(value = NetworkConversionController.class, properties = {"spring.data.elasticsearch.enabled=true"})
-@ContextConfiguration(classes = {NetworkConversionApplication.class, NetworkConversionService.class, EmbeddedElasticsearch.class})
+@WebMvcTest(value = NetworkConversionController.class)
 public class NetworkConversionTest {
 
     @Autowired


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ x] The commit message follows our guidelines

**What is the current behavior?** *(You can also link to an open issue here)*
The  embedded elasticsearch run for all unit tests

**What is the new behavior (if this is a feature change)?**
The  embedded elasticsearch run for only unit tests  that need it

