### PR TITLE
Fix swagger-ui doesn't load: Failed to load API definition.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,6 +31,7 @@
         <springboot.version>2.4.7</springboot.version>
         <springdoc-openapi.version>1.4.8</springdoc-openapi.version>
         <log4j2-mock-version>0.0.2</log4j2-mock-version>
+        <commons-lang3.version>3.9</commons-lang3.version>
         <equalsverifier-version>3.7.1</equalsverifier-version>
         <powsybl-core.version>4.7.0</powsybl-core.version>
         <powsybl-network-store-client.version>1.0.0-SNAPSHOT</powsybl-network-store-client.version>
@@ -124,6 +125,11 @@
                 <groupId>com.powsybl</groupId>
                 <artifactId>powsybl-ws-commons</artifactId>
                 <version>${powsybl-ws-commons.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-lang3</artifactId>
+                <version>${commons-lang3.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.testcontainers</groupId>


### PR DESCRIPTION
On the server we get
network-conversion-server_1      | java.lang.NoSuchMethodError: 'boolean org.apache.commons.lang3.math.NumberUtils.isCreatable(java.lang.String)'
network-conversion-server_1      | 	at io.swagger.v3.core.jackson.ModelResolver.resolveMinimum(ModelResolver.java:1584) ~[swagger-core-2.1.4.jar:2.1.4]

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
BugFix


**What is the current behavior?** *(You can also link to an open issue here)*
swagger-ui.html doesn't not load, crashes at page load.


**What is the new behavior (if this is a feature change)?**
works