### PR TITLE
Reindex network equipments data in elasticsearch

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionController.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionController.java
@@ -100,4 +100,12 @@ public class NetworkConversionController {
         var networkInfos = networkConversionService.importCgmesCase(caseUuid, boundaries);
         return ResponseEntity.ok().body(networkInfos);
     }
+
+    @PostMapping(value = "/networks/{networkUuid}/reindex-all")
+    @Operation(summary = "reindex all equipments in network")
+    public ResponseEntity<Void> reindexAllEquipments(@Parameter(description = "Network UUID") @PathVariable("networkUuid") UUID networkUuid) {
+        LOGGER.debug("reindex all equipments in network");
+        networkConversionService.reindexAllEquipments(networkUuid);
+        return ResponseEntity.ok().build();
+    }
 }

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -25,7 +25,6 @@ import com.powsybl.iidm.export.Exporters;
 import com.powsybl.iidm.mergingview.MergingView;
 import com.powsybl.iidm.network.Identifiable;
 import com.powsybl.iidm.network.Network;
-import com.powsybl.iidm.network.VariantManager;
 import com.powsybl.iidm.network.VariantManagerConstants;
 import com.powsybl.network.conversion.server.dto.BoundaryInfos;
 import com.powsybl.network.conversion.server.dto.EquipmentInfos;
@@ -341,13 +340,6 @@ public class NetworkConversionService {
 
     public void reindexAllEquipments(UUID networkUuid) {
         Network network = getNetwork(networkUuid);
-
-        // delete all variants (except initial one)
-        VariantManager variantManager = network.getVariantManager();
-        Collection<String> variantsToRemove = variantManager.getVariantIds().stream()
-            .filter(id -> !id.equals(VariantManagerConstants.INITIAL_VARIANT_ID))
-            .collect(Collectors.toList());
-        variantsToRemove.forEach(variantManager::removeVariant);
 
         // delete all network equipments infos
         deleteAllEquipmentInfos(networkUuid);

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -346,7 +346,7 @@ public class NetworkConversionService {
         Collection<String> variantsToRemove = variantManager.getVariantIds().stream()
             .filter(id -> !id.equals(VariantManagerConstants.INITIAL_VARIANT_ID))
             .collect(Collectors.toList());
-        variantsToRemove.forEach(v -> variantManager.removeVariant(v));
+        variantsToRemove.forEach(variantManager::removeVariant);
         networkStoreService.flush(network);
 
         // delete all network equipments infos

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -348,7 +348,6 @@ public class NetworkConversionService {
             .filter(id -> !id.equals(VariantManagerConstants.INITIAL_VARIANT_ID))
             .collect(Collectors.toList());
         variantsToRemove.forEach(variantManager::removeVariant);
-        networkStoreService.flush(network);
 
         // delete all network equipments infos
         deleteAllEquipmentInfos(networkUuid);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [ ] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*



**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Feature


**What is the current behavior?** *(You can also link to an open issue here)*
Unable to manually reindex the network equipments data in elasticsearch


**What is the new behavior (if this is a feature change)?**
A rest API is now available to manually reindex the network equipments data in elasticsearch


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
