### PR TITLE
Improve case import duration

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -128,7 +128,7 @@ public class NetworkConversionService {
         CaseDataSourceClient dataSource = new CaseDataSourceClient(caseServerRest, caseUuid);
         ReporterModel reporter = new ReporterModel("importNetwork", "import network");
         AtomicReference<Long> startTime = new AtomicReference<>(System.nanoTime());
-        Network network = networkStoreService.importNetwork(dataSource, reporter, false);
+        Network network = networkStoreService.importNetwork(dataSource, reporter, true);
         if (variantId != null) {
             // cloning network initial variant into variantId
             network.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, variantId);


### PR DESCRIPTION
Signed-off-by: NOIR Nicolas ext <nicolas.noir@rte-france.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [X] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
No


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
This PR improves the case import duration.


**What is the current behavior?** *(You can also link to an open issue here)*
When a case is imported, a variant of the network is also created. Currently, after the network is created from case, it is cloned on conversion server side (to create the variant), before the network and its variant are flushed in database.


**What is the new behavior (if this is a feature change)?**
Now, after the network is created from case, it is flushed in database, and then cloned on database server side (to create the variant), which is much faster.


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
