### PR TITLE
fixup 03aa16c, fix indexing in ES not in parallel of networkstore flush and clone

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -129,22 +129,18 @@ public class NetworkConversionService {
         CaseDataSourceClient dataSource = new CaseDataSourceClient(caseServerRest, caseUuid);
         ReporterModel reporter = new ReporterModel("importNetwork", "import network");
         AtomicReference<Long> startTime = new AtomicReference<>(System.nanoTime());
-        Network network = networkStoreService.importNetwork(dataSource, reporter, true);
-        if (variantId != null) {
-            // cloning network initial variant into variantId
-            network.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, variantId);
-        }
+        Network network = networkStoreService.importNetwork(dataSource, reporter, false);
         UUID networkUuid = networkStoreService.getNetworkUuid(network);
         LOGGER.trace("Import network '{}' : {} seconds", networkUuid, TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startTime.get()));
-        saveNetwork(network, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID, reporter);
+        saveNetwork(network, networkUuid, variantId, reporter);
         return new NetworkInfos(networkUuid, network.getId());
     }
 
     private void saveNetwork(Network network, UUID networkUuid, String variantId, ReporterModel reporter) {
         CompletableFuture<Void> saveInParallel = CompletableFuture.allOf(
-            networkConversionExecutionService.runAsync(() -> flushNetwork(network, networkUuid)),
+            networkConversionExecutionService.runAsync(() -> storeNetworkInitialVariants(network, networkUuid, variantId)),
             networkConversionExecutionService.runAsync(() -> sendReport(networkUuid, reporter)),
-            networkConversionExecutionService.runAsync(() -> insertEquipmentIndexes(network, networkUuid, variantId))
+            networkConversionExecutionService.runAsync(() -> insertEquipmentIndexes(network, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID))
         );
         try {
             saveInParallel.get();
@@ -292,10 +288,14 @@ public class NetworkConversionService {
         }
     }
 
-    private void flushNetwork(Network network, UUID networkUuid) {
+    private void storeNetworkInitialVariants(Network network, UUID networkUuid, String variantId) {
         AtomicReference<Long> startTime = new AtomicReference<>(System.nanoTime());
         try {
             networkStoreService.flush(network);
+            if (variantId != null) {
+                // cloning network initial variant into variantId
+                network.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, variantId);
+            }
         } finally {
             LOGGER.trace("Flush network '{}' in parallel : {} seconds", networkUuid, TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startTime.get()));
         }


### PR DESCRIPTION
Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bugfix


**What is the current behavior?** *(You can also link to an open issue here)*
flush and then ES indexing


**What is the new behavior (if this is a feature change)?**
flus h (and clone) and indexing in parallel


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:
on a real network, indexing takes about 10s and is now done in parallel and not the longest thing to do, so this reduces import time by 10s.