### PR TITLE
Use networkStoreService cloneVariant in import to reduce ram usage

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -303,7 +303,7 @@ public class NetworkConversionService {
             networkStoreService.flush(network);
             if (variantId != null) {
                 // cloning network initial variant into variantId
-                network.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, variantId);
+                networkStoreService.cloneVariant(networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID, variantId, false);
             }
         } finally {
             LOGGER.trace("Flush network '{}' in parallel : {} seconds", networkUuid, TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startTime.get()));

--- a/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
+++ b/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
@@ -54,6 +54,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.verify;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
@@ -121,8 +122,11 @@ public class NetworkConversionTest {
                 .andExpect(status().isOk());
             mvc.perform(post("/v1/networks").param("caseUuid", caseUuid).param("variantId", "second_variant_id"))
                 .andExpect(status().isOk());
-            assertTrue(network.getVariantManager().getVariantIds().contains("first_variant_id"));
-            assertTrue(network.getVariantManager().getVariantIds().contains("second_variant_id"));
+            verify(networkStoreClient).cloneVariant(randomUuid, VariantManagerConstants.INITIAL_VARIANT_ID, "first_variant_id", false);
+            verify(networkStoreClient).cloneVariant(randomUuid, VariantManagerConstants.INITIAL_VARIANT_ID, "second_variant_id", false);
+            //Since the test reuses the same network object, we manually clone the variants so that the rest of the test works
+            network.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, "first_variant_id");
+            network.getVariantManager().cloneVariant(VariantManagerConstants.INITIAL_VARIANT_ID, "second_variant_id");
 
             mvc.perform(get("/v1/export/formats"))
                     .andExpect(status().isOk())


### PR DESCRIPTION
Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
BugFix


**What is the current behavior?** *(You can also link to an open issue here)*
Uses 3gb of ram to import a big network


**What is the new behavior (if this is a feature change)?**
Uses 1.5gb of ram to import a big network


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO
