### PR TITLE
Add consumer import group, needed with multiple pods

### DIFF
--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -15,6 +15,9 @@ spring:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}case.import.failed
         consumeCaseImportStart-in-0:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}case.import.start
+          group: importGroup
+          consumer:
+            concurrency: 1
       source: publishCaseImportStart;publishCaseImportSucceeded;publishCaseImportFailed
       
 network-store-server:


### PR DESCRIPTION
Use concurrency: 1 like in other places

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
NO


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
Bug Fix


**What is the current behavior?** *(You can also link to an open issue here)*
When there are multiple replicas of this microservice, they all try to import the case


**What is the new behavior (if this is a feature change)?**
only one imports the case. One microservice does only one import at a time


**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
