### PR TITLE
Switch standard consumer concurrency from 1 to 2

### DIFF
--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -17,7 +17,7 @@ spring:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}case.import.start
           group: importGroup
           consumer:
-            concurrency: 1
+            concurrency: 2
       source: publishCaseImportStart;publishCaseImportSucceeded;publishCaseImportFailed
       
 network-store-server:


### PR DESCRIPTION
This makes it easier to avoid bugs related to the edge case of concurrency: 1

Signed-off-by: HARPER Jon <jon.harper87@gmail.com>

**Please check if the PR fulfills these requirements** *(please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes)*
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem ?** *If so, link to this issue using `'#XXX'` and skip the rest*
no


**What kind of change does this PR introduce?** *(Bug fix, feature, docs update, ...)*
feature


**What is the current behavior?** *(You can also link to an open issue here)*
only 1 consumer (all imports serialized) for one instance.


**What is the new behavior (if this is a feature change)?**
2 consumers (2 imports in parallel) for one instance. This allows to test that our consumer are correctly thread safe, so if someone wants to use a high concurrency value it will work. Also for us it's a bit better for memory usage to have multiple imports on the same instance.

**Does this PR introduce a breaking change or deprecate an API?** *If yes, check the following:*
NO

**Other information**:

(if any of the questions/checkboxes don't apply, please delete them entirely)
