### PR TITLE
Fix short circuit extension backward compatibility issue

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/GeneratorShortCircuitsXmlSerializer.java
+++ b/src/main/java/com/powsybl/network/conversion/server/GeneratorShortCircuitsXmlSerializer.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.conversion.server;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.AbstractExtensionXmlSerializer;
+import com.powsybl.commons.extensions.ExtensionXmlSerializer;
+import com.powsybl.commons.xml.XmlReaderContext;
+import com.powsybl.commons.xml.XmlUtil;
+import com.powsybl.commons.xml.XmlWriterContext;
+import com.powsybl.iidm.network.Generator;
+import com.powsybl.iidm.network.extensions.GeneratorShortCircuit;
+import com.powsybl.iidm.network.extensions.GeneratorShortCircuitAdder;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+@AutoService(ExtensionXmlSerializer.class)
+public class GeneratorShortCircuitsXmlSerializer extends AbstractExtensionXmlSerializer<Generator, GeneratorShortCircuit> {
+
+    public GeneratorShortCircuitsXmlSerializer() {
+        super("generatorShortCircuits", "network", GeneratorShortCircuit.class, false, "generatorShortCircuits.xsd", "http://www.itesla_project.eu/schema/iidm/ext/generator_short_circuits/1_0",
+                "gsc");
+    }
+
+    @Override
+    public void write(GeneratorShortCircuit extension, XmlWriterContext context) {
+        throw new IllegalStateException("Should not happen");
+    }
+
+    @Override
+    public GeneratorShortCircuit read(Generator extendable, XmlReaderContext context) {
+        float transientReactance = XmlUtil.readFloatAttribute(context.getReader(), "transientReactance");
+        float stepUpTransformerReactance = XmlUtil.readFloatAttribute(context.getReader(), "stepUpTransformerReactance");
+        return extendable.newExtension(GeneratorShortCircuitAdder.class)
+                .withDirectTransX(transientReactance)
+                .withStepUpTransformerX(stepUpTransformerReactance)
+                .add();
+    }
+}

--- a/src/main/java/com/powsybl/network/conversion/server/VoltageLevelShortCircuitsXmlSerializer.java
+++ b/src/main/java/com/powsybl/network/conversion/server/VoltageLevelShortCircuitsXmlSerializer.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.conversion.server;
+
+import com.google.auto.service.AutoService;
+import com.powsybl.commons.extensions.AbstractExtensionXmlSerializer;
+import com.powsybl.commons.extensions.ExtensionXmlSerializer;
+import com.powsybl.commons.xml.XmlReaderContext;
+import com.powsybl.commons.xml.XmlUtil;
+import com.powsybl.commons.xml.XmlWriterContext;
+import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.extensions.IdentifiableShortCircuit;
+import com.powsybl.iidm.network.extensions.IdentifiableShortCircuitAdder;
+
+/**
+ * @author Miora Vedelago <miora.ralambotiana at rte-france.com>
+ */
+@AutoService(ExtensionXmlSerializer.class)
+public class VoltageLevelShortCircuitsXmlSerializer extends AbstractExtensionXmlSerializer<VoltageLevel, IdentifiableShortCircuit<VoltageLevel>> {
+
+    public VoltageLevelShortCircuitsXmlSerializer() {
+        super("voltageLevelShortCircuits", "network", IdentifiableShortCircuit.class,
+                false, "voltageLevelShortCircuits.xsd", "http://www.itesla_project.eu/schema/iidm/ext/voltagelevel_short_circuits/1_0",
+                "vlsc");
+    }
+
+    @Override
+    public void write(IdentifiableShortCircuit<VoltageLevel> extension, XmlWriterContext context) {
+        throw new IllegalStateException("Should not happen");
+    }
+
+    @Override
+    public IdentifiableShortCircuit<VoltageLevel> read(VoltageLevel extendable, XmlReaderContext context) {
+        float minShortCircuitsCurrent = XmlUtil.readFloatAttribute(context.getReader(), "minShortCircuitsCurrent");
+        float maxShortCircuitsCurrent = XmlUtil.readFloatAttribute(context.getReader(), "maxShortCircuitsCurrent");
+        return (IdentifiableShortCircuit<VoltageLevel>) extendable.newExtension(IdentifiableShortCircuitAdder.class)
+                .withIpMin(minShortCircuitsCurrent)
+                .withIpMax(maxShortCircuitsCurrent)
+                .add();
+    }
+}

--- a/src/test/java/com/powsybl/network/conversion/server/ShortCircuitBackwardCompatibilityTest.java
+++ b/src/test/java/com/powsybl/network/conversion/server/ShortCircuitBackwardCompatibilityTest.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2023, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.powsybl.network.conversion.server;
+
+import com.powsybl.iidm.network.Generator;
+import com.powsybl.iidm.network.Network;
+import com.powsybl.iidm.network.VoltageLevel;
+import com.powsybl.iidm.network.extensions.GeneratorShortCircuit;
+import com.powsybl.iidm.network.extensions.IdentifiableShortCircuit;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+/**
+ * @author Geoffroy Jamgotchian <geoffroy.jamgotchian at rte-france.com>
+ */
+public class ShortCircuitBackwardCompatibilityTest {
+
+    @Test
+    public void test() {
+        Network network = Network.read("sc-compat-test.xiidm", getClass().getResourceAsStream("/sc-compat-test.xiidm"));
+        Generator gen = network.getGenerator("GEN");
+        GeneratorShortCircuit genSc = gen.getExtension(GeneratorShortCircuit.class);
+        assertNotNull(genSc);
+        assertEquals(76.9000015258789, genSc.getDirectTransX(), 0);
+        assertTrue(Double.isNaN(genSc.getDirectSubtransX()));
+        assertEquals(30.299999237060547, genSc.getStepUpTransformerX(), 0);
+
+        VoltageLevel vlgen = network.getVoltageLevel("VLGEN");
+        IdentifiableShortCircuit vlgenSc = vlgen.getExtension(IdentifiableShortCircuit.class);
+        assertNotNull(vlgenSc);
+        assertEquals(10, vlgenSc.getIpMin(), 0);
+        assertEquals(1000, vlgenSc.getIpMax(), 0);
+    }
+}

--- a/src/test/resources/sc-compat-test.xiidm
+++ b/src/test/resources/sc-compat-test.xiidm
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<iidm:network xmlns:iidm="http://www.powsybl.org/schema/iidm/1_9" xmlns:gsc="http://www.itesla_project.eu/schema/iidm/ext/generator_short_circuits/1_0" xmlns:vlsc="http://www.itesla_project.eu/schema/iidm/ext/voltagelevel_short_circuits/1_0" id="sim1" caseDate="2013-01-15T18:45:00.000+01:00" forecastDistance="0" sourceFormat="test" minimumValidationLevel="STEADY_STATE_HYPOTHESIS">
+    <iidm:substation id="P1" country="FR" tso="RTE" geographicalTags="A">
+        <iidm:voltageLevel id="VLGEN" nominalV="24.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NGEN" v="24.500000610351563" angle="2.3259763717651367"/>
+            </iidm:busBreakerTopology>
+            <iidm:generator id="GEN" energySource="OTHER" minP="-9999.99" maxP="9999.99" voltageRegulatorOn="true" targetP="607.0" targetV="24.5" targetQ="301.0" bus="NGEN" connectableBus="NGEN" p="-605.558349609375" q="-225.2825164794922">
+                <iidm:minMaxReactiveLimits minQ="-9999.99" maxQ="9999.99"/>
+            </iidm:generator>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLHV1" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV1" v="402.1428451538086" angle="0.0"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NGEN_NHV1" r="0.26658461538461536" x="11.104492831516762" g="0.0" b="0.0" ratedU1="24.0" ratedU2="400.0" bus1="NGEN" connectableBus1="NGEN" voltageLevelId1="VLGEN" bus2="NHV1" connectableBus2="NHV1" voltageLevelId2="VLHV1" p1="605.558349609375" q1="225.2825164794922" p2="-604.8909301757812" q2="-197.48046875"/>
+    </iidm:substation>
+    <iidm:substation id="P2" country="FR" tso="RTE" geographicalTags="B">
+        <iidm:voltageLevel id="VLHV2" nominalV="380.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NHV2" v="389.9526763916016" angle="-3.5063576698303223"/>
+            </iidm:busBreakerTopology>
+        </iidm:voltageLevel>
+        <iidm:voltageLevel id="VLLOAD" nominalV="150.0" topologyKind="BUS_BREAKER">
+            <iidm:busBreakerTopology>
+                <iidm:bus id="NLOAD" v="147.57861328125" angle="-9.614486694335938"/>
+            </iidm:busBreakerTopology>
+            <iidm:load id="LOAD" loadType="UNDEFINED" p0="600.0" q0="200.0" bus="NLOAD" connectableBus="NLOAD" p="600.0" q="200.0"/>
+        </iidm:voltageLevel>
+        <iidm:twoWindingsTransformer id="NHV2_NLOAD" r="0.04724999999999999" x="4.049724365620455" g="0.0" b="0.0" ratedU1="400.0" ratedU2="158.0" bus1="NHV2" connectableBus1="NHV2" voltageLevelId1="VLHV2" bus2="NLOAD" connectableBus2="NLOAD" voltageLevelId2="VLLOAD" p1="600.8677978515625" q1="274.3769836425781" p2="-600.0" q2="-200.0">
+            <iidm:ratioTapChanger lowTapPosition="0" tapPosition="1" loadTapChangingCapabilities="true" regulating="true" targetV="158.0" targetDeadband="0.0">
+                <iidm:terminalRef id="NHV2_NLOAD" side="TWO"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="0.8505666905244191"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.0006666666666666"/>
+                <iidm:step r="0.0" x="0.0" g="0.0" b="0.0" rho="1.150766642808914"/>
+            </iidm:ratioTapChanger>
+        </iidm:twoWindingsTransformer>
+    </iidm:substation>
+    <iidm:line id="NHV1_NHV2_1" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <iidm:line id="NHV1_NHV2_2" r="3.0" x="33.0" g1="0.0" b1="1.93E-4" g2="0.0" b2="1.93E-4" bus1="NHV1" connectableBus1="NHV1" voltageLevelId1="VLHV1" bus2="NHV2" connectableBus2="NHV2" voltageLevelId2="VLHV2" p1="302.4440612792969" q1="98.74027252197266" p2="-300.43389892578125" q2="-137.18849182128906"/>
+    <extension id="GEN">
+        <gsc:generatorShortCircuits transientReactance="76.9" stepUpTransformerReactance="30.3"/>
+    </extension>
+    <extension id="VLGEN">
+        <vlsc:voltageLevelShortCircuits minShortCircuitsCurrent="10" maxShortCircuitsCurrent="1000"/>
+    </extension>
+</iidm:network>


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Bug fix


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Short circuit extensions have been refactored for some years and an incompatibity has been introduced with old serialized xiidm.  


**What is the new behavior (if this is a feature change)?**
Backward compatible serializers has been added.


**Does this PR introduce a breaking change or deprecate an API?**
<!-- If yes, check the following: -->
- [ ] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration guide has been updated in the github wiki *(What changes might users need to make in their application due to this PR?)*


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
