### PR TITLE
Remove the id automatically generated to have a unique index for ELS

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -464,9 +464,7 @@ public class NetworkConversionService {
     }
 
     public List<EquipmentInfos> getAllEquipmentInfos(UUID networkUuid) {
-        List<EquipmentInfos> infos = new ArrayList<>();
-        equipmentInfosService.findAll(networkUuid).forEach(infos::add);
-        return infos;
+        return equipmentInfosService.findAll(networkUuid);
     }
 
     public boolean hasEquipmentInfos(UUID networkUuid) {

--- a/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
+++ b/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
@@ -39,9 +39,9 @@ public class EquipmentInfos {
         return networkUuid + "_" + variantId + "_" + id;
     }
 
-    // No setter because it a composite value
     @SuppressWarnings("unused")
     public void setUniqueId(String uniqueId) {
+        // No setter because it a composite value
     }
 
     @MultiField(

--- a/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
+++ b/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
@@ -10,14 +10,10 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.network.conversion.server.NetworkConversionException;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.AccessType;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.TypeAlias;
-import org.springframework.data.elasticsearch.annotations.Document;
-import org.springframework.data.elasticsearch.annotations.Field;
-import org.springframework.data.elasticsearch.annotations.FieldType;
-import org.springframework.data.elasticsearch.annotations.InnerField;
-import org.springframework.data.elasticsearch.annotations.MultiField;
-import org.springframework.data.elasticsearch.annotations.Setting;
+import org.springframework.data.elasticsearch.annotations.*;
 
 import java.util.Set;
 import java.util.UUID;
@@ -37,7 +33,16 @@ import java.util.stream.Stream;
 @TypeAlias(value = "EquipmentInfos")
 public class EquipmentInfos {
     @Id
-    String uniqueId;
+    @AccessType(AccessType.Type.PROPERTY)
+    @SuppressWarnings("unused")
+    public String getUniqueId() {
+        return networkUuid + "_" + variantId + "_" + id;
+    }
+
+    // No setter because it a composite value
+    @SuppressWarnings("unused")
+    public void setUniqueId(String uniqueId) {
+    }
 
     @MultiField(
         mainField = @Field(name = "equipmentId", type = FieldType.Text),

--- a/src/main/java/com/powsybl/network/conversion/server/elasticsearch/EquipmentInfosRepository.java
+++ b/src/main/java/com/powsybl/network/conversion/server/elasticsearch/EquipmentInfosRepository.java
@@ -10,13 +10,14 @@ import com.powsybl.network.conversion.server.dto.EquipmentInfos;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 import org.springframework.lang.NonNull;
 
+import java.util.List;
 import java.util.UUID;
 
 /**
  * @author Slimane Amar <slimane.amar at rte-france.com>
  */
 public interface EquipmentInfosRepository extends ElasticsearchRepository<EquipmentInfos, String> {
-    Iterable<EquipmentInfos> findAllByNetworkUuid(@NonNull UUID networkUuid);
+    List<EquipmentInfos> findAllByNetworkUuid(@NonNull UUID networkUuid);
 
     long countByNetworkUuid(@NonNull UUID networkUuid);
 

--- a/src/main/java/com/powsybl/network/conversion/server/elasticsearch/EquipmentInfosService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/elasticsearch/EquipmentInfosService.java
@@ -39,7 +39,7 @@ public class EquipmentInfosService {
                 .forEach(equipmentInfosRepository::saveAll);
     }
 
-    public Iterable<EquipmentInfos> findAll(@NonNull UUID networkUuid) {
+    public List<EquipmentInfos> findAll(@NonNull UUID networkUuid) {
         return equipmentInfosRepository.findAllByNetworkUuid(networkUuid);
     }
 

--- a/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceTests.java
+++ b/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceTests.java
@@ -6,7 +6,6 @@
  */
 package com.powsybl.network.conversion.server;
 
-import com.google.common.collect.Iterables;
 import com.powsybl.commons.datasource.ReadOnlyDataSource;
 import com.powsybl.commons.datasource.ResourceDataSource;
 import com.powsybl.commons.datasource.ResourceSet;
@@ -61,7 +60,7 @@ public class EquipmentInfosServiceTests {
         );
         equipmentInfosService.addAll(infos);
         List<EquipmentInfos> infosDB = equipmentInfosService.findAll(NETWORK_UUID);
-        assertEquals(2, Iterables.size(infosDB));
+        assertEquals(2, infosDB.size());
         assertEquals(infos, infosDB);
 
         // Change names but uniqueIds are same
@@ -71,11 +70,11 @@ public class EquipmentInfosServiceTests {
         );
         equipmentInfosService.addAll(infos);
         infosDB = equipmentInfosService.findAll(NETWORK_UUID);
-        assertEquals(2, Iterables.size(infosDB));
+        assertEquals(2, infosDB.size());
         assertEquals(infos, infosDB);
 
         equipmentInfosService.deleteAllOnInitialVariant(NETWORK_UUID);
-        assertEquals(0, Iterables.size(equipmentInfosService.findAll(NETWORK_UUID)));
+        assertEquals(0, equipmentInfosService.findAll(NETWORK_UUID).size());
     }
 
     @Test
@@ -85,7 +84,7 @@ public class EquipmentInfosServiceTests {
         UUID networkUuid = UUID.randomUUID();
 
         VoltageLevel vl = network.getVoltageLevel("BBE1AA1");
-        EquipmentInfos equipmentInfos = networkConversionService.toEquipmentInfos(vl, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
+        EquipmentInfos equipmentInfos = NetworkConversionService.toEquipmentInfos(vl, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
         EquipmentInfos expectedEquipmentInfos = EquipmentInfos.builder()
                 .networkUuid(networkUuid)
                 .variantId(VariantManagerConstants.INITIAL_VARIANT_ID)
@@ -98,7 +97,7 @@ public class EquipmentInfosServiceTests {
         assertEquals(expectedEquipmentInfos, equipmentInfos);
 
         Substation substation = network.getSubstation("BBE1AA");
-        equipmentInfos = networkConversionService.toEquipmentInfos(substation, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
+        equipmentInfos = NetworkConversionService.toEquipmentInfos(substation, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
         expectedEquipmentInfos = EquipmentInfos.builder()
                 .networkUuid(networkUuid)
                 .variantId(VariantManagerConstants.INITIAL_VARIANT_ID)
@@ -117,7 +116,7 @@ public class EquipmentInfosServiceTests {
         assertEquals(expectedEquipmentInfos, equipmentInfos);
 
         Switch switch1 = network.getSwitch("FRA1AA1_switch");
-        equipmentInfos = networkConversionService.toEquipmentInfos(switch1, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
+        equipmentInfos = NetworkConversionService.toEquipmentInfos(switch1, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
         expectedEquipmentInfos = EquipmentInfos.builder()
                 .networkUuid(networkUuid)
                 .variantId(VariantManagerConstants.INITIAL_VARIANT_ID)
@@ -130,7 +129,7 @@ public class EquipmentInfosServiceTests {
         assertEquals(expectedEquipmentInfos, equipmentInfos);
 
         Load load = network.getLoad("BBE1AA1 _load");
-        equipmentInfos = networkConversionService.toEquipmentInfos(load, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
+        equipmentInfos = NetworkConversionService.toEquipmentInfos(load, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
         expectedEquipmentInfos = EquipmentInfos.builder()
                 .networkUuid(networkUuid)
                 .variantId(VariantManagerConstants.INITIAL_VARIANT_ID)
@@ -143,7 +142,7 @@ public class EquipmentInfosServiceTests {
         assertEquals(expectedEquipmentInfos, equipmentInfos);
 
         Bus bus = network.getBusBreakerView().getBus("BBE1AA1 ");
-        equipmentInfos = networkConversionService.toEquipmentInfos(bus, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
+        equipmentInfos = NetworkConversionService.toEquipmentInfos(bus, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
         expectedEquipmentInfos = EquipmentInfos.builder()
                 .networkUuid(networkUuid)
                 .variantId(VariantManagerConstants.INITIAL_VARIANT_ID)
@@ -156,7 +155,7 @@ public class EquipmentInfosServiceTests {
         assertEquals(expectedEquipmentInfos, equipmentInfos);
 
         Generator generator = network.getGenerator("BBE1AA1 _generator");
-        equipmentInfos = networkConversionService.toEquipmentInfos(generator, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
+        equipmentInfos = NetworkConversionService.toEquipmentInfos(generator, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
         expectedEquipmentInfos = EquipmentInfos.builder()
                 .networkUuid(networkUuid)
                 .variantId(VariantManagerConstants.INITIAL_VARIANT_ID)
@@ -169,7 +168,7 @@ public class EquipmentInfosServiceTests {
         assertEquals(expectedEquipmentInfos, equipmentInfos);
 
         HvdcLine hvdcLine = network.getHvdcLine("FRA1AA_BBE1AA_hvdcline");
-        equipmentInfos = networkConversionService.toEquipmentInfos(hvdcLine, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
+        equipmentInfos = NetworkConversionService.toEquipmentInfos(hvdcLine, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
         expectedEquipmentInfos = EquipmentInfos.builder()
                 .networkUuid(networkUuid)
                 .variantId(VariantManagerConstants.INITIAL_VARIANT_ID)
@@ -182,7 +181,7 @@ public class EquipmentInfosServiceTests {
         assertEquals(expectedEquipmentInfos, equipmentInfos);
 
         TwoWindingsTransformer twoWindingsTransformer = network.getTwoWindingsTransformer("BBE1AA2  BBE3AA1  2");
-        equipmentInfos = networkConversionService.toEquipmentInfos(twoWindingsTransformer, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
+        equipmentInfos = NetworkConversionService.toEquipmentInfos(twoWindingsTransformer, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
         expectedEquipmentInfos = EquipmentInfos.builder()
                 .networkUuid(networkUuid)
                 .variantId(VariantManagerConstants.INITIAL_VARIANT_ID)
@@ -195,7 +194,7 @@ public class EquipmentInfosServiceTests {
         assertEquals(expectedEquipmentInfos, equipmentInfos);
 
         ThreeWindingsTransformer threeWindingsTransformer = network.getThreeWindingsTransformer("BBE1AA_w3t");
-        equipmentInfos = networkConversionService.toEquipmentInfos(threeWindingsTransformer, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
+        equipmentInfos = NetworkConversionService.toEquipmentInfos(threeWindingsTransformer, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
         expectedEquipmentInfos = EquipmentInfos.builder()
                 .networkUuid(networkUuid)
                 .variantId(VariantManagerConstants.INITIAL_VARIANT_ID)
@@ -208,7 +207,7 @@ public class EquipmentInfosServiceTests {
         assertEquals(expectedEquipmentInfos, equipmentInfos);
 
         Line line = network.getLine("BBE1AA1  BBE2AA1  1");
-        equipmentInfos = networkConversionService.toEquipmentInfos(line, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
+        equipmentInfos = NetworkConversionService.toEquipmentInfos(line, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
         expectedEquipmentInfos = EquipmentInfos.builder()
                 .networkUuid(networkUuid)
                 .variantId(VariantManagerConstants.INITIAL_VARIANT_ID)
@@ -226,7 +225,7 @@ public class EquipmentInfosServiceTests {
         networkUuid = UUID.randomUUID();
 
         line = network.getLine("LINE_S1VL1");
-        equipmentInfos = networkConversionService.toEquipmentInfos(line, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
+        equipmentInfos = NetworkConversionService.toEquipmentInfos(line, networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
         expectedEquipmentInfos = EquipmentInfos.builder()
                 .networkUuid(networkUuid)
                 .variantId(VariantManagerConstants.INITIAL_VARIANT_ID)

--- a/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceTests.java
+++ b/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceTests.java
@@ -28,8 +28,6 @@ import org.springframework.test.context.junit4.SpringRunner;
 import java.util.List;
 import java.util.Set;
 import java.util.UUID;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 
 import static org.junit.Assert.*;
 
@@ -61,13 +59,20 @@ public class EquipmentInfosServiceTests {
             EquipmentInfos.builder().networkUuid(NETWORK_UUID).variantId(VariantManagerConstants.INITIAL_VARIANT_ID).id("id1").name("name1").type(IdentifiableType.LOAD.name()).voltageLevels(Set.of(VoltageLevelInfos.builder().id("vl1").name("vl1").build())).substations(Set.of(SubstationInfos.builder().id("s1").name("s1").build())).build(),
             EquipmentInfos.builder().networkUuid(NETWORK_UUID).variantId(VariantManagerConstants.INITIAL_VARIANT_ID).id("id2").name("name2").type(IdentifiableType.LOAD.name()).voltageLevels(Set.of(VoltageLevelInfos.builder().id("vl2").name("vl2").build())).substations(Set.of(SubstationInfos.builder().id("s2").name("s2").build())).build()
         );
-
         equipmentInfosService.addAll(infos);
-        Iterable<EquipmentInfos> all = equipmentInfosService.findAll(NETWORK_UUID);
-        assertEquals(2, Iterables.size(all));
-        List<EquipmentInfos> allList = StreamSupport.stream(all.spliterator(), false)
-                .collect(Collectors.toList());
-        assertEquals(infos, allList);
+        List<EquipmentInfos> infosDB = equipmentInfosService.findAll(NETWORK_UUID);
+        assertEquals(2, Iterables.size(infosDB));
+        assertEquals(infos, infosDB);
+
+        // Change names but uniqueIds are same
+        infos = List.of(
+            EquipmentInfos.builder().networkUuid(NETWORK_UUID).variantId(VariantManagerConstants.INITIAL_VARIANT_ID).id("id1").name("newName1").type(IdentifiableType.LOAD.name()).voltageLevels(Set.of(VoltageLevelInfos.builder().id("vl1").name("vl1").build())).substations(Set.of(SubstationInfos.builder().id("s1").name("s1").build())).build(),
+            EquipmentInfos.builder().networkUuid(NETWORK_UUID).variantId(VariantManagerConstants.INITIAL_VARIANT_ID).id("id2").name("newName2").type(IdentifiableType.LOAD.name()).voltageLevels(Set.of(VoltageLevelInfos.builder().id("vl2").name("vl2").build())).substations(Set.of(SubstationInfos.builder().id("s2").name("s2").build())).build()
+        );
+        equipmentInfosService.addAll(infos);
+        infosDB = equipmentInfosService.findAll(NETWORK_UUID);
+        assertEquals(2, Iterables.size(infosDB));
+        assertEquals(infos, infosDB);
 
         equipmentInfosService.deleteAllOnInitialVariant(NETWORK_UUID);
         assertEquals(0, Iterables.size(equipmentInfosService.findAll(NETWORK_UUID)));

--- a/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceTests.java
+++ b/src/test/java/com/powsybl/network/conversion/server/EquipmentInfosServiceTests.java
@@ -62,6 +62,7 @@ public class EquipmentInfosServiceTests {
         List<EquipmentInfos> infosDB = equipmentInfosService.findAll(NETWORK_UUID);
         assertEquals(2, infosDB.size());
         assertEquals(infos, infosDB);
+        assertEquals(infos.stream().map(i -> i.getNetworkUuid() + "_" + i.getVariantId() + "_" + i.getId()).toList(), infosDB.stream().map(i -> i.getUniqueId()).toList());
 
         // Change names but uniqueIds are same
         infos = List.of(
@@ -72,6 +73,7 @@ public class EquipmentInfosServiceTests {
         infosDB = equipmentInfosService.findAll(NETWORK_UUID);
         assertEquals(2, infosDB.size());
         assertEquals(infos, infosDB);
+        assertEquals(infos.stream().map(i -> i.getNetworkUuid() + "_" + i.getVariantId() + "_" + i.getId()).toList(), infosDB.stream().map(i -> i.getUniqueId()).toList());
 
         equipmentInfosService.deleteAllOnInitialVariant(NETWORK_UUID);
         assertEquals(0, equipmentInfosService.findAll(NETWORK_UUID).size());


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [ x] The commit message follows our guidelines
- [ x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**What is the current behavior?**
Id for new equipment doc ELS are automatically generated
When we modify the same equipment the doc ELS is not replaced and a new one is created



**What is the new behavior (if this is a feature change)?**
Now when we modify the same equipment which already indexed the doc ELS is replaced 


