### PR TITLE
Refactor case import methods  to avoid making a request to get caseFormat

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionController.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionController.java
@@ -54,6 +54,7 @@ public class NetworkConversionController {
     @PostMapping(value = "/networks")
     @Operation(summary = "Get a case file from its name and import it into the store")
     public ResponseEntity<NetworkInfos> importCase(@Parameter(description = "Case UUID") @RequestParam("caseUuid") UUID caseUuid,
+                                                   @Parameter(description = "Case format") @RequestParam(name = "caseFormat") String caseFormat,
                                                    @Parameter(description = "Variant ID") @RequestParam(name = "variantId", required = false) String variantId,
                                                    @Parameter(description = "Report UUID") @RequestParam(value = "reportUuid", required = false) UUID reportUuid,
                                                    @Parameter(description = "Import parameters") @RequestBody(required = false) Map<String, Object> importParameters,
@@ -62,11 +63,11 @@ public class NetworkConversionController {
         LOGGER.debug("Importing case {} {}...", caseUuid, isAsyncRun ? "asynchronously" : "synchronously");
         Map<String, Object> nonNullImportParameters = importParameters == null ? new HashMap<>() : importParameters;
         if (!isAsyncRun) {
-            NetworkInfos networkInfos = networkConversionService.importCase(caseUuid, variantId, reportUuid, nonNullImportParameters);
+            NetworkInfos networkInfos = networkConversionService.importCase(caseUuid, variantId, reportUuid, caseFormat, nonNullImportParameters);
             return ResponseEntity.ok().body(networkInfos);
         }
 
-        networkConversionService.importCaseAsynchronously(caseUuid, variantId, reportUuid, nonNullImportParameters, receiver);
+        networkConversionService.importCaseAsynchronously(caseUuid, variantId, reportUuid, caseFormat, nonNullImportParameters, receiver);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/powsybl/network/conversion/server/NotificationService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NotificationService.java
@@ -10,7 +10,6 @@ package com.powsybl.network.conversion.server;
  * @author Kevin Le Saulnier <kevin.lesaulnier at rte-france.com>
  */
 
-import com.powsybl.network.conversion.server.dto.CaseInfos;
 import com.powsybl.network.conversion.server.dto.NetworkInfos;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,21 +55,22 @@ public class NotificationService {
         networkConversionPublisher.send("publishCaseImportFailed-out-0", message);
     }
 
-    public void emitCaseImportStart(UUID caseUuid, String variantId, UUID reportUuid, Map<String, Object> importParameters, String receiver) {
+    public void emitCaseImportStart(UUID caseUuid, String variantId, UUID reportUuid, String caseFormat, Map<String, Object> importParameters, String receiver) {
         sendCaseImportStartMessage(MessageBuilder.withPayload(caseUuid)
                 .setHeader(HEADER_VARIANT_ID, variantId)
                 .setHeader(HEADER_REPORT_UUID, reportUuid != null ? reportUuid.toString() : null)
                 .setHeader(HEADER_IMPORT_PARAMETERS, importParameters)
                 .setHeader(HEADER_RECEIVER, receiver)
+                .setHeader(HEADER_CASE_FORMAT, caseFormat)
                 .build());
     }
 
-    public void emitCaseImportSucceeded(NetworkInfos networkInfos, CaseInfos caseInfos, String receiver, Map<String, String> importParameters) {
+    public void emitCaseImportSucceeded(NetworkInfos networkInfos, String caseNameStr, String caseFormatStr, String receiver, Map<String, String> importParameters) {
         sendCaseImportSucceededMessage(MessageBuilder.withPayload("")
                 .setHeader(HEADER_NETWORK_ID, networkInfos.getNetworkId())
                 .setHeader(HEADER_NETWORK_UUID, networkInfos.getNetworkUuid().toString())
-                .setHeader(HEADER_CASE_FORMAT, caseInfos.getFormat())
-                .setHeader(HEADER_CASE_NAME, caseInfos.getName())
+                .setHeader(HEADER_CASE_FORMAT, caseFormatStr)
+                .setHeader(HEADER_CASE_NAME, caseNameStr)
                 .setHeader(HEADER_RECEIVER, receiver)
                 .setHeader(HEADER_IMPORT_PARAMETERS, importParameters)
                 .build());

--- a/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
+++ b/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
@@ -137,7 +137,8 @@ public class NetworkConversionTest {
             MvcResult mvcResult = mvc.perform(post("/v1/networks")
                 .param("caseUuid", caseUuid)
                 .param("reportUuid", UUID.randomUUID().toString())
-                .param("isAsyncRun", "false"))
+                .param("isAsyncRun", "false")
+                .param("caseFormat", "XIIDM"))
                 .andExpect(status().isOk())
                 .andReturn();
 
@@ -149,13 +150,15 @@ public class NetworkConversionTest {
                 .param("caseUuid", caseUuid)
                 .param("variantId", "first_variant_id")
                 .param("isAsyncRun", "false")
-                .param("reportUuid", UUID.randomUUID().toString()))
+                .param("reportUuid", UUID.randomUUID().toString())
+                .param("caseFormat", "XIIDM"))
                 .andExpect(status().isOk());
             mvc.perform(post("/v1/networks")
                 .param("caseUuid", caseUuid)
                 .param("variantId", "second_variant_id")
                 .param("isAsyncRun", "false")
-                .param("reportUuid", UUID.randomUUID().toString()))
+                .param("reportUuid", UUID.randomUUID().toString())
+                .param("caseFormat", "XIIDM"))
                 .andExpect(status().isOk());
 
             verify(networkStoreClient).cloneVariant(randomUuid, VariantManagerConstants.INITIAL_VARIANT_ID, "first_variant_id");
@@ -257,13 +260,15 @@ public class NetworkConversionTest {
                     .param("caseUuid", caseUuid)
                     .param("variantId", "import_params_variant_id")
                     .param("reportUuid", UUID.randomUUID().toString())
-                    .param("isAsyncRun", "false"))
+                    .param("isAsyncRun", "false")
+                    .param("caseFormat", "XIIDM"))
                     .andExpect(status().isOk());
 
             // test without report
             mvc.perform(post("/v1/networks")
                             .param("caseUuid", caseUuid)
-                            .param("isAsyncRun", "false"))
+                            .param("isAsyncRun", "false")
+                            .param("caseFormat", "XIIDM"))
                     .andExpect(status().isOk());
 
             // test without report and with an error at flush
@@ -271,7 +276,8 @@ public class NetworkConversionTest {
                     .when(networkStoreClient).flush(network);
             mvc.perform(post("/v1/networks")
                             .param("caseUuid", caseUuid)
-                            .param("isAsyncRun", "false"))
+                            .param("isAsyncRun", "false")
+                            .param("caseFormat", "XIIDM"))
                     .andExpect(status().isInternalServerError());
         }
     }
@@ -302,7 +308,8 @@ public class NetworkConversionTest {
                 .param("caseUuid", caseUuid)
                 .param("variantId", "async_variant_id")
                 .param("reportUuid", UUID.randomUUID().toString())
-                .param("receiver", receiver))
+                .param("receiver", receiver)
+                .param("caseFormat", "XIIDM"))
                 .andExpect(status().isOk());
 
         Message<byte[]> message = output.receive(1000, "case.import.succeeded");
@@ -337,7 +344,8 @@ public class NetworkConversionTest {
                 .param("caseUuid", caseUuid)
                 .param("variantId", "async_failure_variant_id")
                 .param("reportUuid", UUID.randomUUID().toString())
-                .param("receiver", receiver))
+                .param("receiver", receiver)
+                .param("caseFormat", "XIIDM"))
                 .andExpect(status().isOk());
 
         Message<byte[]> message = output.receive(1000, "case.import.failed");
@@ -471,7 +479,8 @@ public class NetworkConversionTest {
         MvcResult mvcResult = mvc.perform(post("/v1/networks")
             .param("caseUuid", caseUuid.toString())
             .param("reportUuid", reportUuid.toString())
-            .param("isAsyncRun", "false"))
+            .param("isAsyncRun", "false")
+            .param("caseFormat", "XIIDM"))
             .andExpect(status().isOk())
             .andReturn();
 
@@ -499,7 +508,7 @@ public class NetworkConversionTest {
                 .willReturn(new ResponseEntity<>(HttpStatus.OK));
         given(caseServerRest.getForEntity(eq("/v1/cases/" + caseUuid + "/infos"), any())).willReturn(ResponseEntity.ok(new CaseInfos(UUID.fromString(caseUuid.toString()), "testCase", "XIIDM")));
 
-        String message = assertThrows(NetworkConversionException.class, () -> networkConversionService.importCase(caseUuid, null, reportUuid, EMPTY_PARAMETERS)).getMessage();
+        String message = assertThrows(NetworkConversionException.class, () -> networkConversionService.importCase(caseUuid, null, reportUuid, "XIIDM", EMPTY_PARAMETERS)).getMessage();
         assertTrue(message.contains(String.format("The save of network '%s' has failed", networkUuid)));
     }
 
@@ -526,7 +535,7 @@ public class NetworkConversionTest {
             .willReturn(ResponseEntity.ok("testCase"));
         given(caseServerRest.getForEntity(eq("/v1/cases/" + caseUuid + "/infos"), any())).willReturn(ResponseEntity.ok(new CaseInfos(UUID.fromString(caseUuid.toString()), "testCase", "XIIDM")));
 
-        String message = assertThrows(NetworkConversionException.class, () -> networkConversionService.importCase(caseUuid, null, reportUuid, EMPTY_PARAMETERS)).getMessage();
+        String message = assertThrows(NetworkConversionException.class, () -> networkConversionService.importCase(caseUuid, null, reportUuid, "XIIDM", EMPTY_PARAMETERS)).getMessage();
         assertTrue(message.contains(String.format("The save of network '%s' has failed", networkUuid)));
     }
 


### PR DESCRIPTION
This pull request introduces a change in the POST /networks endpoint.
The change allows the caseFormat to be passed as a parameter instead of requesting the caseServer to retrieve the caseFormat.

**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Optimisation


**What is the current behavior?**
<!-- You can also link to an open issue here -->
the importCase method relies on the "GET /v1/cases/caseUuid/infos" to fetch the case format from the case-server. However, this approach introduces unnecessary dependencies and potential network overhead.


**What is the new behavior (if this is a feature change)?**
This pull request modifies the importCase endpoint POST /networks in the NetworkConversionController  to accept the caseFormat as a parameter instead of requesting the case-server to retrieve the case format.




**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [ ] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
Users of the application will need to update their code to include the caseFormat parameter when calling the importCase endpoint. Previously, the caseFormat was obtained from the caseServer, but now it needs to be provided explicitly.


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
