### PR TITLE
Override default parameters for CGMES

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -76,6 +76,8 @@ public class NetworkConversionService {
 
     private static final String IMPORT_TYPE_REPORT = "ImportNetwork";
 
+    public static final Map<String, Object> IMPORT_PARAMETERS_DEFAULT_VALUE_OVERRIDE = Map.of("iidm.import.cgmes.cgm-with-subnetworks", false);
+
     private RestTemplate caseServerRest;
 
     private RestTemplate geoDataServerRest;
@@ -145,7 +147,8 @@ public class NetworkConversionService {
         Map<String, String> defaultValues = new HashMap<>();
         importer.getParameters()
                 .stream()
-                .forEach(parameter -> defaultValues.put(parameter.getName(), parameter.getDefaultValue() != null ? parameter.getDefaultValue().toString() : ""));
+                .forEach(parameter -> defaultValues.put(parameter.getName(),
+                        parameter.getDefaultValue() != null ? IMPORT_PARAMETERS_DEFAULT_VALUE_OVERRIDE.getOrDefault(parameter.getName(), parameter.getDefaultValue()).toString() : ""));
         return defaultValues;
     }
 
@@ -346,7 +349,9 @@ public class NetworkConversionService {
         List<ParamMeta> paramsMeta = importer.getParameters()
                 .stream()
                 .filter(pp -> pp.getScope().equals(ParameterScope.FUNCTIONAL))
-                .map(pp -> new ParamMeta(pp.getName(), pp.getType(), pp.getDescription(), pp.getDefaultValue(), pp.getPossibleValues()))
+                .map(pp -> new ParamMeta(pp.getName(), pp.getType(), pp.getDescription(),
+                        IMPORT_PARAMETERS_DEFAULT_VALUE_OVERRIDE.getOrDefault(pp.getName(), pp.getDefaultValue()),
+                        pp.getPossibleValues()))
                 .collect(Collectors.toList());
         return new ImportExportFormatMeta(caseInfos.getFormat(), paramsMeta);
     }

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -76,6 +76,7 @@ public class NetworkConversionService {
 
     private static final String IMPORT_TYPE_REPORT = "ImportNetwork";
 
+    // Temporary fix to override default import parameter from Powsybl while merge is not implemented in the network-store
     public static final Map<String, Object> IMPORT_PARAMETERS_DEFAULT_VALUE_OVERRIDE = Map.of("iidm.import.cgmes.cgm-with-subnetworks", false);
 
     private RestTemplate caseServerRest;
@@ -171,6 +172,9 @@ public class NetworkConversionService {
             changedImportParameters.forEach((k, v) -> allImportParameters.put(k, v.toString()));
             CaseInfos caseInfos = getCaseInfos(caseUuid);
             getDefaultImportParameters(caseInfos).forEach(allImportParameters::putIfAbsent);
+            IMPORT_PARAMETERS_DEFAULT_VALUE_OVERRIDE.entrySet().stream()
+                    .filter(entry -> allImportParameters.containsKey(entry.getKey()))
+                    .forEach(entry -> changedImportParameters.putIfAbsent(entry.getKey(), entry.getValue()));
 
             try {
                 NetworkInfos networkInfos = importCase(caseUuid, variantId, reportUuid, caseInfos.getFormat(), changedImportParameters);


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**What kind of change does this PR introduce?**
In the network-store, we didn't implement Network.merge() yet. When importing CGMES, this is required if the parameter **iidm.import.cgmes.cgm-with-subnetworks** is **true** which is the case by default:
https://github.com/powsybl/powsybl-core/blob/99f68d080ecdd380db108a71d399adad71ef36f9/cgmes/cgmes-conversion/src/main/java/com/powsybl/cgmes/conversion/CgmesImport.java#L158-L162
In this PR, we override the default parameter **iidm.import.cgmes.cgm-with-subnetworks** to set it to **false**.