### PR TITLE
Limit import/export with queue in memory + supervision

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/ImportExportExecutionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/ImportExportExecutionService.java
@@ -1,0 +1,41 @@
+/**
+ * Copyright (c) 2025, RTE (http://www.rte-france.com)
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.conversion.server;
+
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.function.Supplier;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import jakarta.annotation.PreDestroy;
+import lombok.NonNull;
+
+/**
+ * @author Sylvain Bouzols <sylvain.bouzols_externe at rte-france.com>
+ */
+@Service
+public class ImportExportExecutionService {
+    private ThreadPoolExecutor executorService;
+
+    public ImportExportExecutionService(@Value("${max-concurrent-import-export}") int maxConcurrentImportExport,
+                                                    @NonNull NetworkConversionObserver networkConversionObserver) {
+        executorService = (ThreadPoolExecutor) Executors.newFixedThreadPool(maxConcurrentImportExport);
+        networkConversionObserver.createThreadPoolMetric(executorService);
+    }
+
+    @PreDestroy
+    private void preDestroy() {
+        executorService.shutdown();
+    }
+
+    public <U> CompletableFuture<U> supplyAsync(Supplier<U> supplier) {
+        return CompletableFuture.supplyAsync(supplier, executorService);
+    }
+}

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionException.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionException.java
@@ -22,7 +22,8 @@ public final class NetworkConversionException extends RuntimeException {
         UNKNOWN_EQUIPMENT_TYPE(HttpStatus.INTERNAL_SERVER_ERROR),
         UNKNOWN_VARIANT_ID(HttpStatus.NOT_FOUND),
         FAILED_NETWORK_SAVING(HttpStatus.INTERNAL_SERVER_ERROR),
-        FAILED_CASE_IMPORT(HttpStatus.INTERNAL_SERVER_ERROR);
+        FAILED_CASE_IMPORT(HttpStatus.INTERNAL_SERVER_ERROR),
+        FAILED_CASE_EXPORT(HttpStatus.INTERNAL_SERVER_ERROR);
 
         public final HttpStatus status;
 
@@ -72,5 +73,9 @@ public final class NetworkConversionException extends RuntimeException {
 
     public static NetworkConversionException createFailedCaseImport(Exception cause) {
         return new NetworkConversionException(Type.FAILED_CASE_IMPORT, "Case import failed", cause);
+    }
+
+    public static NetworkConversionException createFailedCaseExport(Exception cause) {
+        return new NetworkConversionException(Type.FAILED_CASE_EXPORT, "Case export failed", cause);
     }
 }

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -210,9 +210,7 @@ public class NetworkConversionService {
 
     public NetworkInfos importCase(UUID caseUuid, String variantId, UUID reportUuid, String caseFormat, Map<String, Object> importParameters) {
         try {
-            return importExportExecutionService.supplyAsync(() -> {
-                return importCaseExec(caseUuid, variantId, reportUuid, caseFormat, importParameters);
-            }).join();
+            return importExportExecutionService.supplyAsync(() -> importCaseExec(caseUuid, variantId, reportUuid, caseFormat, importParameters)).join();
         } catch (CompletionException e) {
             if (e.getCause() instanceof NetworkConversionException exception) {
                 throw exception;

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -47,6 +47,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
@@ -84,6 +85,7 @@ public class NetworkConversionService {
 
     private final NotificationService notificationService;
 
+    private final ImportExportExecutionService importExportExecutionService;
     private final NetworkConversionObserver networkConversionObserver;
 
     private final ObjectMapper objectMapper;
@@ -95,12 +97,14 @@ public class NetworkConversionService {
                                     EquipmentInfosService equipmentInfosService,
                                     NetworkConversionExecutionService networkConversionExecutionService,
                                     NotificationService notificationService,
-                                    NetworkConversionObserver networkConversionObserver) {
+                                    NetworkConversionObserver networkConversionObserver,
+                                    ImportExportExecutionService importExportExecutionService) {
         this.networkStoreService = networkStoreService;
         this.equipmentInfosService = equipmentInfosService;
         this.networkConversionExecutionService = networkConversionExecutionService;
         this.notificationService = notificationService;
         this.networkConversionObserver = networkConversionObserver;
+        this.importExportExecutionService = importExportExecutionService;
 
         RestTemplateBuilder restTemplateBuilder = new RestTemplateBuilder();
         caseServerRest = restTemplateBuilder.build();
@@ -172,9 +176,8 @@ public class NetworkConversionService {
         };
     }
 
-    NetworkInfos importCase(UUID caseUuid, String variantId, UUID reportUuid, String caseFormat, Map<String, Object> importParameters) {
+    private NetworkInfos importCaseExec(UUID caseUuid, String variantId, UUID reportUuid, String caseFormat, Map<String, Object> importParameters) {
         CaseDataSourceClient dataSource = new CaseDataSourceClient(caseServerRest, caseUuid);
-
         ReportNode rootReport = ReportNode.NO_OP;
         ReportNode reporter = ReportNode.NO_OP;
         if (reportUuid != null) {
@@ -187,7 +190,6 @@ public class NetworkConversionService {
             reporter = rootReport.newReportNode()
                     .withMessageTemplate(subReporterId, subReporterId)
                     .add();
-
         }
 
         AtomicReference<Long> startTime = new AtomicReference<>(System.nanoTime());
@@ -204,6 +206,19 @@ public class NetworkConversionService {
         LOGGER.trace("Import network '{}' : {} seconds", networkUuid, TimeUnit.NANOSECONDS.toSeconds(System.nanoTime() - startTime.get()));
         saveNetwork(network, networkUuid, variantId, rootReport, reportUuid);
         return new NetworkInfos(networkUuid, network.getId());
+    }
+
+    public NetworkInfos importCase(UUID caseUuid, String variantId, UUID reportUuid, String caseFormat, Map<String, Object> importParameters) {
+        try {
+            return importExportExecutionService.supplyAsync(() -> {
+                return importCaseExec(caseUuid, variantId, reportUuid, caseFormat, importParameters);
+            }).join();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof NetworkConversionException exception) {
+                throw exception;
+            }
+            throw NetworkConversionException.createFailedCaseImport(e);
+        }
     }
 
     private void saveNetwork(Network network, UUID networkUuid, String variantId, ReportNode reporter, UUID reportUuid) {
@@ -273,7 +288,7 @@ public class NetworkConversionService {
         }
     }
 
-    ExportNetworkInfos exportNetwork(UUID networkUuid, String variantId, String fileName,
+    private ExportNetworkInfos exportNetworkExec(UUID networkUuid, String variantId, String fileName,
         String format, Map<String, Object> formatParameters) throws IOException {
         if (!Exporter.getFormats().contains(format)) {
             throw NetworkConversionException.createFormatUnsupported(format);
@@ -309,6 +324,24 @@ public class NetworkConversionService {
         }
         long networkSize = network.getBusView().getBusStream().count();
         return new ExportNetworkInfos(fileOrNetworkName, networkData, networkSize);
+    }
+
+    public ExportNetworkInfos exportNetwork(UUID networkUuid, String variantId, String fileName,
+        String format, Map<String, Object> formatParameters) {
+        try {
+            return importExportExecutionService.supplyAsync(() -> {
+                try {
+                    return exportNetworkExec(networkUuid, variantId, fileName, format, formatParameters);
+                } catch (IOException e) {
+                    throw NetworkConversionException.createFailedCaseExport(e);
+                }
+            }).join();
+        } catch (CompletionException e) {
+            if (e.getCause() instanceof NetworkConversionException exception) {
+                throw exception;
+            }
+            throw NetworkConversionException.createFailedCaseExport(e);
+        }
     }
 
     private String getNetworkName(Network network, String variantId) {

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -39,3 +39,7 @@ management:
   health:
     solr:
       enabled: false
+
+# maximum concurrent network import/export
+# to avoid out of memory issues
+max-concurrent-import-export: 2

--- a/src/main/resources/config/application.yaml
+++ b/src/main/resources/config/application.yaml
@@ -15,7 +15,7 @@ spring:
           destination: ${powsybl-ws.rabbitmq.destination.prefix:}case.import.start
           group: importGroup
           consumer:
-            concurrency: 2
+            concurrency: 2 # pay attention to max-concurrent-import-export parameter
             max-attempts: 1
       output-bindings: publishCaseImportStart-out-0;publishCaseImportSucceeded-out-0
       rabbit:
@@ -42,4 +42,6 @@ management:
 
 # maximum concurrent network import/export
 # to avoid out of memory issues
+# WARNING: pay attention for imports, that spring.cloud.stream.bindings.consumeCaseImportStart-in-0.consumer.concurrency
+# is consistent with this parameter value
 max-concurrent-import-export: 2


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No

**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
feature

**Does this PR introduce a new Powsybl Action implying to be implemented in simulators or pypowsybl?**
- [ ] Yes, the corresponding issue is [here](link)
- [x] No

**What is the current behavior?**
<!-- You can also link to an open issue here -->
Multiple import/export could run simultaneously then OOMKill could occur

**What is the new behaviour (if this is a feature change)?**
An in memory queue is implemented to limit simultaneous import/export to 2.
2 imports OR
2 exports OR
1 import + 1 export

**Does this PR introduce a breaking change or deprecate an API?**
- [ ] Yes
- [x] No
