### PR TITLE
Reindex all variants

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionException.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionException.java
@@ -24,7 +24,8 @@ public final class NetworkConversionException extends RuntimeException {
         UNKNOWN_VARIANT_ID(HttpStatus.NOT_FOUND),
         FAILED_NETWORK_SAVING(HttpStatus.INTERNAL_SERVER_ERROR),
         FAILED_CASE_IMPORT(HttpStatus.INTERNAL_SERVER_ERROR),
-        FAILED_CASE_EXPORT(HttpStatus.INTERNAL_SERVER_ERROR);
+        FAILED_CASE_EXPORT(HttpStatus.INTERNAL_SERVER_ERROR),
+        FAILED_NETWORK_REINDEX(HttpStatus.INTERNAL_SERVER_ERROR);
 
         public final HttpStatus status;
 
@@ -85,4 +86,7 @@ public final class NetworkConversionException extends RuntimeException {
         return new NetworkConversionException(Type.UNSUPPORTED_HYBRID_HVDC, String.format("The hybrid Hvdc line %s is unsupported", hvdcId));
     }
 
+    public static NetworkConversionException createFailedNetworkReindex(UUID networkUuid, Exception cause) {
+        return new NetworkConversionException(Type.FAILED_NETWORK_REINDEX, String.format("Reindex of network '%s' has failed", networkUuid), cause);
+    }
 }

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -542,13 +542,11 @@ public class NetworkConversionService {
 
                 // check if there are changes between current and initial variants infos
                 List<EquipmentInfos> modifiedEquipmentInfos = currentVariantEquipmentInfos.entrySet().stream()
-                        .filter(entry -> initialVariantEquipmentInfos.containsKey(entry.getKey()))
-                        .map(entry -> {
+                        .filter(entry -> {
                             EquipmentInfos initialEquipmentInfo = initialVariantEquipmentInfos.get(entry.getKey());
-                            EquipmentInfos currentEquipmentInfo = entry.getValue();
-                            return !Objects.equals(initialEquipmentInfo, currentEquipmentInfo) ? currentEquipmentInfo : null;
+                            return initialEquipmentInfo != null && !Objects.equals(initialEquipmentInfo, entry.getValue());
                         })
-                        .filter(Objects::nonNull)
+                        .map(Map.Entry::getValue)
                         .toList();
 
                 List<TombstonedEquipmentInfos> tombstonedEquipmentInfos = initialVariantEquipmentInfos.keySet().stream()

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -578,6 +578,14 @@ public class NetworkConversionService {
         return equipmentInfosService.findAll(networkUuid);
     }
 
+    public List<EquipmentInfos> getAllEquipmentInfosByNetworkUuidAndVariantId(UUID networkUuid, String variantId) {
+        return equipmentInfosService.findAllByNetworkUuidAndVariantId(networkUuid, variantId);
+    }
+
+    public List<TombstonedEquipmentInfos> getAllTombstonedEquipmentInfosByNetworkUuidAndVariantId(UUID networkUuid, String variantId) {
+        return equipmentInfosService.findAllTombstonedByNetworkUuidAndVariantId(networkUuid, variantId);
+    }
+
     public boolean hasEquipmentInfos(UUID networkUuid) {
         return equipmentInfosService.count(networkUuid) > 0;
     }

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -477,9 +477,8 @@ public class NetworkConversionService {
     }
 
     private Map<String, EquipmentInfos> getEquipmentInfos(Network network, UUID networkUuid, String variantId) {
-        return network.getIdentifiables()
-                .stream()
-                .filter(c -> TYPES_FOR_INDEXING.contains(c.getType()))
+        return TYPES_FOR_INDEXING.stream()
+                .flatMap(network::getIdentifiableStream)
                 .collect(Collectors.toMap(Identifiable::getId, equipment -> toEquipmentInfos(equipment, networkUuid, variantId)));
     }
 

--- a/src/main/java/com/powsybl/network/conversion/server/dto/BasicEquipmentInfos.java
+++ b/src/main/java/com/powsybl/network/conversion/server/dto/BasicEquipmentInfos.java
@@ -1,0 +1,54 @@
+/*
+  Copyright (c) 2021, RTE (http://www.rte-france.com)
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.conversion.server.dto;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.AccessType;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+import org.springframework.data.elasticsearch.annotations.InnerField;
+import org.springframework.data.elasticsearch.annotations.MultiField;
+
+import java.util.UUID;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+@SuperBuilder
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString
+@EqualsAndHashCode
+public class BasicEquipmentInfos {
+    @Id
+    @AccessType(AccessType.Type.PROPERTY)
+    @SuppressWarnings("unused")
+    public String getUniqueId() {
+        return networkUuid + "_" + variantId + "_" + id;
+    }
+
+    @SuppressWarnings("unused")
+    public void setUniqueId(String uniqueId) {
+        // No setter because it a composite value
+    }
+
+    @MultiField(
+        mainField = @Field(name = "equipmentId", type = FieldType.Text),
+        otherFields = {
+            @InnerField(suffix = "fullascii", type = FieldType.Keyword, normalizer = "fullascii"),
+            @InnerField(suffix = "raw", type = FieldType.Keyword)
+        }
+    )
+    private String id;
+
+    private UUID networkUuid;
+
+    private String variantId;
+}

--- a/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
+++ b/src/main/java/com/powsybl/network/conversion/server/dto/EquipmentInfos.java
@@ -10,70 +10,45 @@ import com.powsybl.iidm.network.*;
 import com.powsybl.network.conversion.server.NetworkConversionException;
 import lombok.*;
 import lombok.experimental.SuperBuilder;
-import org.springframework.data.annotation.AccessType;
-import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.TypeAlias;
 import org.springframework.data.elasticsearch.annotations.*;
+import org.springframework.lang.NonNull;
 
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 /**
  * @author Slimane Amar <slimane.amar at rte-france.com>
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
  */
 @SuperBuilder
 @NoArgsConstructor
 @Getter
-@ToString
-@EqualsAndHashCode
+@Setter
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
 @Document(indexName = "#{@environment.getProperty('powsybl-ws.elasticsearch.index.prefix')}equipments")
 @Setting(settingPath = "elasticsearch_settings.json")
 @TypeAlias(value = "EquipmentInfos")
-public class EquipmentInfos {
-    @Id
-    @AccessType(AccessType.Type.PROPERTY)
-    @SuppressWarnings("unused")
-    public String getUniqueId() {
-        return networkUuid + "_" + variantId + "_" + id;
-    }
-
-    @SuppressWarnings("unused")
-    public void setUniqueId(String uniqueId) {
-        // No setter because it a composite value
-    }
-
+public class EquipmentInfos extends BasicEquipmentInfos {
     @MultiField(
-        mainField = @Field(name = "equipmentId", type = FieldType.Text),
-        otherFields = {
-            @InnerField(suffix = "fullascii", type = FieldType.Keyword, normalizer = "fullascii"),
-            @InnerField(suffix = "raw", type = FieldType.Keyword)
-        }
+            mainField = @Field(name = "equipmentName", type = FieldType.Text),
+            otherFields = {
+                @InnerField(suffix = "fullascii", type = FieldType.Keyword, normalizer = "fullascii"),
+                @InnerField(suffix = "raw", type = FieldType.Keyword)
+            }
     )
-    String id;
-
-    @MultiField(
-        mainField = @Field(name = "equipmentName", type = FieldType.Text),
-        otherFields = {
-            @InnerField(suffix = "fullascii", type = FieldType.Keyword, normalizer = "fullascii"),
-            @InnerField(suffix = "raw", type = FieldType.Keyword)
-        }
-    )
-    String name;
+    private String name;
 
     @Field("equipmentType")
-    String type;
+    private String type;
 
     @Field(type = FieldType.Nested, includeInParent = true)
-    Set<VoltageLevelInfos> voltageLevels;
+    private Set<VoltageLevelInfos> voltageLevels;
 
     @Field(type = FieldType.Nested, includeInParent = true)
     private Set<SubstationInfos> substations;
-
-    UUID networkUuid;
-
-    String variantId;
 
     public static Set<VoltageLevel> getVoltageLevels(@NonNull Identifiable<?> identifiable) {
         if (identifiable instanceof Substation) {

--- a/src/main/java/com/powsybl/network/conversion/server/dto/TombstonedEquipmentInfos.java
+++ b/src/main/java/com/powsybl/network/conversion/server/dto/TombstonedEquipmentInfos.java
@@ -1,0 +1,28 @@
+/*
+  Copyright (c) 2022, RTE (http://www.rte-france.com)
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.conversion.server.dto;
+
+import lombok.*;
+import lombok.experimental.SuperBuilder;
+import org.springframework.data.annotation.TypeAlias;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Setting;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+@SuperBuilder
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString(callSuper = true)
+@EqualsAndHashCode(callSuper = true)
+@Document(indexName = "#{@environment.getProperty('powsybl-ws.elasticsearch.index.prefix')}tombstoned-equipments")
+@Setting(settingPath = "elasticsearch_settings.json")
+@TypeAlias(value = "TombstonedEquipmentInfos")
+public class TombstonedEquipmentInfos extends BasicEquipmentInfos {
+}

--- a/src/main/java/com/powsybl/network/conversion/server/elasticsearch/EquipmentInfosRepository.java
+++ b/src/main/java/com/powsybl/network/conversion/server/elasticsearch/EquipmentInfosRepository.java
@@ -22,4 +22,6 @@ public interface EquipmentInfosRepository extends ElasticsearchRepository<Equipm
     long countByNetworkUuid(@NonNull UUID networkUuid);
 
     void deleteAllByNetworkUuidAndVariantId(@NonNull UUID networkUuid, @NonNull String variantId);
+
+    void deleteAllByNetworkUuid(@NonNull UUID networkUuid);
 }

--- a/src/main/java/com/powsybl/network/conversion/server/elasticsearch/EquipmentInfosRepository.java
+++ b/src/main/java/com/powsybl/network/conversion/server/elasticsearch/EquipmentInfosRepository.java
@@ -19,6 +19,8 @@ import java.util.UUID;
 public interface EquipmentInfosRepository extends ElasticsearchRepository<EquipmentInfos, String> {
     List<EquipmentInfos> findAllByNetworkUuid(@NonNull UUID networkUuid);
 
+    List<EquipmentInfos> findAllByNetworkUuidAndVariantId(UUID networkUuid, String variantId);
+
     long countByNetworkUuid(@NonNull UUID networkUuid);
 
     void deleteAllByNetworkUuidAndVariantId(@NonNull UUID networkUuid, @NonNull String variantId);

--- a/src/main/java/com/powsybl/network/conversion/server/elasticsearch/EquipmentInfosService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/elasticsearch/EquipmentInfosService.java
@@ -9,6 +9,7 @@ package com.powsybl.network.conversion.server.elasticsearch;
 import com.google.common.collect.Lists;
 import com.powsybl.iidm.network.VariantManagerConstants;
 import com.powsybl.network.conversion.server.dto.EquipmentInfos;
+import com.powsybl.network.conversion.server.dto.TombstonedEquipmentInfos;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.lang.NonNull;
 import org.springframework.stereotype.Service;
@@ -29,14 +30,23 @@ public class EquipmentInfosService {
 
     private final EquipmentInfosRepository equipmentInfosRepository;
 
-    public EquipmentInfosService(EquipmentInfosRepository equipmentInfosRepository) {
+    private final TombstonedEquipmentInfosRepository tombstonedEquipmentInfosRepository;
+
+    public EquipmentInfosService(EquipmentInfosRepository equipmentInfosRepository, TombstonedEquipmentInfosRepository tombstonedEquipmentInfosRepository) {
         this.equipmentInfosRepository = equipmentInfosRepository;
+        this.tombstonedEquipmentInfosRepository = tombstonedEquipmentInfosRepository;
     }
 
     public void addAll(@NonNull final List<EquipmentInfos> equipmentsInfos) {
         Lists.partition(equipmentsInfos, partitionSize)
                 .parallelStream()
                 .forEach(equipmentInfosRepository::saveAll);
+    }
+
+    public void addAllTombstonedEquipmentInfos(@NonNull final List<TombstonedEquipmentInfos> tombstonedEquipmentInfos) {
+        Lists.partition(tombstonedEquipmentInfos, partitionSize)
+                .parallelStream()
+                .forEach(tombstonedEquipmentInfosRepository::saveAll);
     }
 
     public List<EquipmentInfos> findAll(@NonNull UUID networkUuid) {
@@ -49,5 +59,9 @@ public class EquipmentInfosService {
 
     public void deleteAllOnInitialVariant(@NonNull UUID networkUuid) {
         equipmentInfosRepository.deleteAllByNetworkUuidAndVariantId(networkUuid, VariantManagerConstants.INITIAL_VARIANT_ID);
+    }
+
+    public void deleteAllByNetworkUuid(@NonNull UUID networkUuid) {
+        equipmentInfosRepository.deleteAllByNetworkUuid(networkUuid);
     }
 }

--- a/src/main/java/com/powsybl/network/conversion/server/elasticsearch/EquipmentInfosService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/elasticsearch/EquipmentInfosService.java
@@ -53,6 +53,14 @@ public class EquipmentInfosService {
         return equipmentInfosRepository.findAllByNetworkUuid(networkUuid);
     }
 
+    public List<EquipmentInfos> findAllByNetworkUuidAndVariantId(UUID networkUuid, String variantId) {
+        return equipmentInfosRepository.findAllByNetworkUuidAndVariantId(networkUuid, variantId);
+    }
+
+    public List<TombstonedEquipmentInfos> findAllTombstonedByNetworkUuidAndVariantId(UUID networkUuid, String variantId) {
+        return tombstonedEquipmentInfosRepository.findAllByNetworkUuidAndVariantId(networkUuid, variantId);
+    }
+
     public long count(@NonNull UUID networkUuid) {
         return equipmentInfosRepository.countByNetworkUuid(networkUuid);
     }

--- a/src/main/java/com/powsybl/network/conversion/server/elasticsearch/TombstonedEquipmentInfosRepository.java
+++ b/src/main/java/com/powsybl/network/conversion/server/elasticsearch/TombstonedEquipmentInfosRepository.java
@@ -1,0 +1,16 @@
+/*
+  Copyright (c) 2022, RTE (http://www.rte-france.com)
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+package com.powsybl.network.conversion.server.elasticsearch;
+
+import com.powsybl.network.conversion.server.dto.TombstonedEquipmentInfos;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+/**
+ * @author Nicolas Noir <nicolas.noir at rte-france.com>
+ */
+public interface TombstonedEquipmentInfosRepository extends ElasticsearchRepository<TombstonedEquipmentInfos, String> {
+}

--- a/src/main/java/com/powsybl/network/conversion/server/elasticsearch/TombstonedEquipmentInfosRepository.java
+++ b/src/main/java/com/powsybl/network/conversion/server/elasticsearch/TombstonedEquipmentInfosRepository.java
@@ -9,8 +9,12 @@ package com.powsybl.network.conversion.server.elasticsearch;
 import com.powsybl.network.conversion.server.dto.TombstonedEquipmentInfos;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
+import java.util.List;
+import java.util.UUID;
+
 /**
  * @author Nicolas Noir <nicolas.noir at rte-france.com>
  */
 public interface TombstonedEquipmentInfosRepository extends ElasticsearchRepository<TombstonedEquipmentInfos, String> {
+    List<TombstonedEquipmentInfos> findAllByNetworkUuidAndVariantId(UUID networkUuid, String variantId);
 }

--- a/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
+++ b/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
@@ -608,6 +608,14 @@ class NetworkConversionTest {
         assertEquals(1, tombstonedEquipmentInfos.size());
     }
 
+    @Test
+    void testReindexThrows() {
+        UUID networkUuid = UUID.fromString("78e13f90-f351-4c2e-a383-2ad08dd5f8fb");
+        given(networkStoreClient.getNetwork(networkUuid, PreloadingStrategy.ALL_COLLECTIONS_NEEDED_FOR_BUS_VIEW)).willThrow(new PowsyblException("Network not found"));
+        NetworkConversionException e = assertThrows(NetworkConversionException.class, () -> networkConversionService.reindexAllEquipments(networkUuid));
+        assertEquals("Reindex of network '" + networkUuid + "' has failed", e.getMessage());
+    }
+
     private static Network createNetwork(String prefix) {
         Network network = NetworkFactory.findDefault().createNetwork(prefix + "network", "test");
         Substation p1 = network.newSubstation()

--- a/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
+++ b/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
@@ -166,7 +166,7 @@ class NetworkConversionTest {
 
             UUID notFoundNetworkUuid = UUID.randomUUID();
             given(networkStoreClient.getNetwork(notFoundNetworkUuid)).willThrow(new PowsyblException("Network " + notFoundNetworkUuid.toString() + " not found"));
-            given(networkStoreClient.getNetwork(any(UUID.class), eq(PreloadingStrategy.COLLECTION))).willReturn(network);
+            given(networkStoreClient.getNetwork(any(UUID.class), eq(PreloadingStrategy.ALL_COLLECTIONS_NEEDED_FOR_BUS_VIEW))).willReturn(network);
             mvcResult = mvc.perform(post("/v1/networks/{networkUuid}/export/{format}", UUID.randomUUID().toString(), "XIIDM"))
                     .andExpect(status().isOk())
                     .andExpect(content().contentTypeCompatibleWith(MediaType.APPLICATION_OCTET_STREAM))
@@ -217,7 +217,7 @@ class NetworkConversionTest {
                         .andReturn();
 
             UUID networkUuid = UUID.fromString("f3a85c9b-9594-4e55-8ec7-07ea965d24eb");
-            networkConversionService.deleteAllEquipmentInfosOnInitialVariant(networkUuid);
+            networkConversionService.deleteAllEquipmentInfosByNetworkUuid(networkUuid);
             List<EquipmentInfos> infos = networkConversionService.getAllEquipmentInfos(networkUuid);
             assertTrue(infos.isEmpty());
 
@@ -233,8 +233,8 @@ class NetworkConversionTest {
                 .andExpect(status().isOk())
                 .andReturn();
             infos = networkConversionService.getAllEquipmentInfos(networkUuid);
-            // exclude switch since it is not indexed
-            assertEquals(91, infos.size());
+            // exclude switch, bus bar section and bus since it is not indexed
+            assertEquals(74, infos.size());
 
             mvc.perform(head("/v1/networks/{networkUuid}/indexed-equipments", networkUuid.toString()))
                 .andExpect(status().isOk())
@@ -358,7 +358,7 @@ class NetworkConversionTest {
         Network network = new CgmesImport()
                 .importData(CgmesConformity1Catalog.microGridBaseCaseBE().dataSource(), NetworkFactory.findDefault(), null);
         UUID networkUuid = UUID.fromString("7928181c-7977-4592-ba19-88027e4254e7");
-        given(networkStoreClient.getNetwork(networkUuid, PreloadingStrategy.COLLECTION)).willReturn(network);
+        given(networkStoreClient.getNetwork(networkUuid, PreloadingStrategy.ALL_COLLECTIONS_NEEDED_FOR_BUS_VIEW)).willReturn(network);
 
         MvcResult mvcResult = mvc.perform(get("/v1/networks/{networkUuid}/export-sv-cgmes", networkUuid))
                 .andExpect(status().isOk())

--- a/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
+++ b/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
@@ -564,7 +564,7 @@ class NetworkConversionTest {
         network.getVariantManager().setWorkingVariant(VariantManagerConstants.INITIAL_VARIANT_ID);
 
         UUID networkUuid = UUID.fromString("78e13f90-f351-4c2e-a383-2ad08dd5f8fb");
-        given(networkStoreClient.getNetwork(eq(networkUuid), eq(PreloadingStrategy.ALL_COLLECTIONS_NEEDED_FOR_BUS_VIEW))).willReturn(network);
+        given(networkStoreClient.getNetwork(networkUuid, PreloadingStrategy.ALL_COLLECTIONS_NEEDED_FOR_BUS_VIEW)).willReturn(network);
 
         networkConversionService.reindexAllEquipments(networkUuid);
         // Initial variant has 12 indexed elements (no switches, bbs, bus)


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines

**Does this PR already have an issue describing the problem?**
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->
No


**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
* Remove indexation of BBS and BUS and use a whitelist
* Reindex all variants of the network instead of only the initial variant 


**What is the current behavior?**
<!-- You can also link to an open issue here -->
* BBS and BUS are indexed
* Only the initial variant is reindexed


**What is the new behavior (if this is a feature change)?**
* BBS and BUS are not indexed and we use a whitelist
* Reindex all variants of the network instead of only the initial variant 