### PR TITLE
Enhance network conversion metrics with total and processing observations for import/export operations

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionController.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionController.java
@@ -87,10 +87,7 @@ public class NetworkConversionController {
                                                              @org.springframework.web.bind.annotation.RequestBody(required = false) Map<String, Object> formatParameters
                                                              ) {
         LOGGER.debug("Exporting network {}...", networkUuid);
-        ExportNetworkInfos exportNetworkInfos = networkConversionObserver.observeExport(
-                format,
-                () -> networkConversionService.exportNetwork(networkUuid, variantId, fileName, format, formatParameters)
-        );
+        ExportNetworkInfos exportNetworkInfos = networkConversionService.exportNetwork(networkUuid, variantId, fileName, format, formatParameters);
 
         return networkConversionService.createExportNetworkResponse(exportNetworkInfos, StandardCharsets.UTF_8);
     }
@@ -133,7 +130,7 @@ public class NetworkConversionController {
     @Operation(summary = "Export a cgmes network from the network-store")
     public ResponseEntity<byte[]> exportCgmesSv(@Parameter(description = "Network UUID") @PathVariable("networkUuid") UUID networkUuid) throws XMLStreamException {
         LOGGER.debug("Exporting network {}...", networkUuid);
-        ExportNetworkInfos exportNetworkInfos = networkConversionObserver.observeExport("CGMES", () -> networkConversionService.exportCgmesSv(networkUuid));
+        ExportNetworkInfos exportNetworkInfos = networkConversionService.exportCgmesSv(networkUuid);
         HttpHeaders header = new HttpHeaders();
         header.setContentDisposition(ContentDisposition.builder("attachment").filename(exportNetworkInfos.getNetworkName(), StandardCharsets.UTF_8).build());
         return ResponseEntity.ok().headers(header).contentType(MediaType.APPLICATION_OCTET_STREAM).body(exportNetworkInfos.getNetworkData());

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionObserver.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionObserver.java
@@ -30,9 +30,13 @@ public class NetworkConversionObserver {
     private static final String FORMAT_TAG_NAME = "format";
 
     private static final String IMPORT_OBSERVATION_NAME = OBSERVATION_PREFIX + "import";
+    private static final String IMPORT_TOTAL_OBSERVATION_NAME = OBSERVATION_PREFIX + "import.total";
+    private static final String IMPORT_PROCESSING_OBSERVATION_NAME = OBSERVATION_PREFIX + "import.processing";
     private static final String NUMBER_BUSES_IMPORTED_METER_NAME = IMPORT_OBSERVATION_NAME + ".buses";
 
     private static final String EXPORT_OBSERVATION_NAME = OBSERVATION_PREFIX + "export";
+    private static final String EXPORT_TOTAL_OBSERVATION_NAME = OBSERVATION_PREFIX + "export.total";
+    private static final String EXPORT_PROCESSING_OBSERVATION_NAME = OBSERVATION_PREFIX + "export.processing";
     private static final String NUMBER_BUSES_EXPORTED_METER_NAME = EXPORT_OBSERVATION_NAME + ".buses";
 
     private static final String TASK_TYPE_TAG_NAME = "type";
@@ -49,17 +53,24 @@ public class NetworkConversionObserver {
         this.meterRegistry = meterRegistry;
     }
 
-    public <E extends Throwable> ExportNetworkInfos observeExport(String format, Observation.CheckedCallable<ExportNetworkInfos, E> callable) throws E {
-        Observation observation = createObservation(EXPORT_OBSERVATION_NAME, format);
-        ExportNetworkInfos exportInfos = observation.observeChecked(callable);
+    public <T, E extends Throwable> T observeExportTotal(String format, Observation.CheckedCallable<T, E> callable) throws E {
+        return createObservation(EXPORT_TOTAL_OBSERVATION_NAME, format).observeChecked(callable);
+    }
+
+    public <E extends Throwable> ExportNetworkInfos observeExportProcessing(String format, Observation.CheckedCallable<ExportNetworkInfos, E> callable) throws E {
+        ExportNetworkInfos exportInfos = createObservation(EXPORT_PROCESSING_OBSERVATION_NAME, format).observeChecked(callable);
         if (exportInfos != null) {
             recordNumberBuses(NUMBER_BUSES_EXPORTED_METER_NAME, format, exportInfos.getNumberBuses());
         }
         return exportInfos;
     }
 
-    public <E extends Throwable> Network observeImport(String format, Observation.CheckedCallable<Network, E> callable) throws E {
-        Network network = createObservation(IMPORT_OBSERVATION_NAME, format).observeChecked(callable);
+    public <T, E extends Throwable> T observeImportTotal(String format, Observation.CheckedCallable<T, E> callable) throws E {
+        return createObservation(IMPORT_TOTAL_OBSERVATION_NAME, format).observeChecked(callable);
+    }
+
+    public <E extends Throwable> Network observeImportProcessing(String format, Observation.CheckedCallable<Network, E> callable) throws E {
+        Network network = createObservation(IMPORT_PROCESSING_OBSERVATION_NAME, format).observeChecked(callable);
         if (network != null) {
             recordNumberBuses(NUMBER_BUSES_IMPORTED_METER_NAME, format, network.getBusView().getBusStream().count());
         }


### PR DESCRIPTION
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?** no
<!-- If so, link to this issue using `'Fixes #XXX'` and skip the rest -->



**What kind of change does this PR introduce?**
<!-- Bug fix, feature, docs update, ... -->
Feature enhancement - Dual metrics observability for network conversion operations


**What is the current behavior?**
<!-- You can also link to an open issue here -->
Network conversion metrics are inconsistent - export operations capture total time (including queue wait) while import operations only capture processing time, creating misleading performance comparisons and incomplete monitoring visibility.


**What is the new behavior (if this is a feature change)?**

Implements consistent dual observation pattern for both import and export operations that separately measures:

Total time (end-to-end user experience including queue wait)
Processing time (pure computational work)
This provides complete visibility into both user experience and system performance across all operations.


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

**If yes, please check if the following requirements are fulfilled**
<!-- If no breaking changes or API deprecations were introduced, delete this section -->
- [x] The *Breaking Change* or *Deprecated* label has been added
- [x] The migration steps are described in the following section

**What changes might users need to make in their application due to this PR? (migration steps)**
<!-- If this PR introduces a breaking change, describe the migration steps -->
<!-- The content of this section will be copied in the migration guide -->
. Update Grafana dashboards to use new metric names:

- app_conversion_import_seconds_* → app_conversion_import_total_seconds_* and app_conversion_import_processing_seconds_*
- app_conversion_export_seconds_* → app_conversion_export_total_seconds_* and app_conversion_export_processing_seconds_*


. Bus metrics now use app_conversion_*_processing_buses_* naming


**Other information**:
<!-- if any of the questions/checkboxes don't apply, please delete them entirely -->
