### PR TITLE
Fix import params

### DIFF
--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -24,6 +24,7 @@ import com.powsybl.network.conversion.server.dto.*;
 import com.powsybl.network.conversion.server.elasticsearch.EquipmentInfosService;
 import com.powsybl.network.store.client.NetworkStoreService;
 import com.powsybl.network.store.client.PreloadingStrategy;
+import com.rabbitmq.client.LongString;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.slf4j.Logger;
@@ -404,10 +405,10 @@ public class NetworkConversionService {
                 Properties importProperties = new Properties();
                 importParameters.forEach((k, v) -> {
                     if (v != null) {
-                        importProperties.put(k, v);
+                        // String longer than 1024 bytes are converted to com.rabbitmq.client.LongString (https://docs.spring.io/spring-amqp/docs/3.0.0/reference/html/#message-properties-converters)
+                        importProperties.put(k, (v instanceof LongString) ? v.toString() : v);
                     }
                 });
-                importProperties.putAll(importParameters);
                 return networkStoreService.importNetwork(dataSource, finalReporter, importProperties, false);
             } else {
                 return networkStoreService.importNetwork(dataSource, finalReporter, false);

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -220,6 +220,11 @@ public class NetworkConversionService {
             CaseInfos caseInfos = getCaseInfos(caseUuid);
             getDefaultImportParameters(caseInfos).forEach(allImportParameters::putIfAbsent);
 
+            //TODO: to be removed when upgrade to next powsybl-core release (should be v7.3).
+            // iidm.die.excluded-extensions default value will be changed to null so that we can import a network with all the default values.
+            if (caseInfos.getFormat().equals("DIE")) {
+                allImportParameters.remove("iidm.die.excluded-extensions");
+            }
             NetworkInfos networkInfos = importCase(caseUuid, variantId, reportUuid, caseInfos.getFormat(), allImportParameters);
             notificationService.emitCaseImportSucceeded(networkInfos, caseInfos.getName(), caseInfos.getFormat(), receiver, allImportParameters);
         };

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -215,17 +215,17 @@ public class NetworkConversionService {
             String receiver = message.getHeaders().get(NotificationService.HEADER_RECEIVER, String.class);
             Map<String, Object> rawParameters = (Map<String, Object>) message.getHeaders().get(NotificationService.HEADER_IMPORT_PARAMETERS);
             // String longer than 1024 bytes are converted to com.rabbitmq.client.LongString (https://docs.spring.io/spring-amqp/docs/3.0.0/reference/html/#message-properties-converters)
-            Map<String, Object> changedImportParameters = new HashMap<>();
-            if (rawParameters != null) {
-                rawParameters.forEach((key, value) -> changedImportParameters.put(key, value.toString()));
-            }
+//            Map<String, Object> changedImportParameters = new HashMap<>();
+//            if (rawParameters != null) {
+//                rawParameters.forEach((key, value) -> changedImportParameters.put(key, value.toString()));
+//            }
 
             Map<String, Object> allImportParameters = new HashMap<>();
-            changedImportParameters.forEach((k, v) -> allImportParameters.put(k, v.toString()));
+            rawParameters.forEach((k, v) -> allImportParameters.put(k, v));
             CaseInfos caseInfos = getCaseInfos(caseUuid);
             getDefaultImportParameters(caseInfos).forEach(allImportParameters::putIfAbsent);
 
-            NetworkInfos networkInfos = importCase(caseUuid, variantId, reportUuid, caseInfos.getFormat(), changedImportParameters);
+            NetworkInfos networkInfos = importCase(caseUuid, variantId, reportUuid, caseInfos.getFormat(), allImportParameters);
             notificationService.emitCaseImportSucceeded(networkInfos, caseInfos.getName(), caseInfos.getFormat(), receiver, allImportParameters);
         };
     }
@@ -402,6 +402,11 @@ public class NetworkConversionService {
         Network network = networkConversionObserver.observeImportProcessing(caseFormat, () -> {
             if (!importParameters.isEmpty()) {
                 Properties importProperties = new Properties();
+                importParameters.forEach((k, v) -> {
+                    if (v != null) {
+                        importProperties.put(k, v);
+                    }
+                });
                 importProperties.putAll(importParameters);
                 return networkStoreService.importNetwork(dataSource, finalReporter, importProperties, false);
             } else {

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -216,7 +216,7 @@ public class NetworkConversionService {
             String receiver = message.getHeaders().get(NotificationService.HEADER_RECEIVER, String.class);
             Map<String, Object> rawParameters = (Map<String, Object>) message.getHeaders().get(NotificationService.HEADER_IMPORT_PARAMETERS);
             Map<String, Object> allImportParameters = new HashMap<>();
-            rawParameters.forEach((k, v) -> allImportParameters.put(k, v));
+            rawParameters.forEach(allImportParameters::put);
             CaseInfos caseInfos = getCaseInfos(caseUuid);
             getDefaultImportParameters(caseInfos).forEach(allImportParameters::putIfAbsent);
 

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -215,12 +215,6 @@ public class NetworkConversionService {
             UUID reportUuid = reportUuidStr != null ? UUID.fromString(reportUuidStr) : null;
             String receiver = message.getHeaders().get(NotificationService.HEADER_RECEIVER, String.class);
             Map<String, Object> rawParameters = (Map<String, Object>) message.getHeaders().get(NotificationService.HEADER_IMPORT_PARAMETERS);
-            // String longer than 1024 bytes are converted to com.rabbitmq.client.LongString (https://docs.spring.io/spring-amqp/docs/3.0.0/reference/html/#message-properties-converters)
-//            Map<String, Object> changedImportParameters = new HashMap<>();
-//            if (rawParameters != null) {
-//                rawParameters.forEach((key, value) -> changedImportParameters.put(key, value.toString()));
-//            }
-
             Map<String, Object> allImportParameters = new HashMap<>();
             rawParameters.forEach((k, v) -> allImportParameters.put(k, v));
             CaseInfos caseInfos = getCaseInfos(caseUuid);

--- a/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NetworkConversionService.java
@@ -187,13 +187,12 @@ public class NetworkConversionService {
         notificationService.emitCaseExportStart(caseUuid, fileName, format, userId, exportUuid, formatParameters);
     }
 
-    Map<String, String> getDefaultImportParameters(CaseInfos caseInfos) {
+    Map<String, Object> getDefaultImportParameters(CaseInfos caseInfos) {
         Importer importer = Importer.find(caseInfos.getFormat());
-        Map<String, String> defaultValues = new HashMap<>();
+        Map<String, Object> defaultValues = new HashMap<>();
         importer.getParameters()
                 .stream()
-                .forEach(parameter -> defaultValues.put(parameter.getName(),
-                        parameter.getDefaultValue() != null ? parameter.getDefaultValue().toString() : ""));
+                .forEach(parameter -> defaultValues.put(parameter.getName(), parameter.getDefaultValue()));
         return defaultValues;
     }
 
@@ -221,7 +220,7 @@ public class NetworkConversionService {
                 rawParameters.forEach((key, value) -> changedImportParameters.put(key, value.toString()));
             }
 
-            Map<String, String> allImportParameters = new HashMap<>();
+            Map<String, Object> allImportParameters = new HashMap<>();
             changedImportParameters.forEach((k, v) -> allImportParameters.put(k, v.toString()));
             CaseInfos caseInfos = getCaseInfos(caseUuid);
             getDefaultImportParameters(caseInfos).forEach(allImportParameters::putIfAbsent);

--- a/src/main/java/com/powsybl/network/conversion/server/NotificationService.java
+++ b/src/main/java/com/powsybl/network/conversion/server/NotificationService.java
@@ -89,7 +89,7 @@ public class NotificationService {
                 .build());
     }
 
-    public void emitCaseImportSucceeded(NetworkInfos networkInfos, String caseNameStr, String caseFormatStr, String receiver, Map<String, String> importParameters) {
+    public void emitCaseImportSucceeded(NetworkInfos networkInfos, String caseNameStr, String caseFormatStr, String receiver, Map<String, Object> importParameters) {
         sendCaseImportSucceededMessage(MessageBuilder.withPayload("")
                 .setHeader(HEADER_NETWORK_ID, networkInfos.getNetworkId())
                 .setHeader(HEADER_NETWORK_UUID, networkInfos.getNetworkUuid().toString())

--- a/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
+++ b/src/test/java/com/powsybl/network/conversion/server/NetworkConversionTest.java
@@ -421,7 +421,7 @@ class NetworkConversionTest {
             .willReturn(ResponseEntity.ok("testCase"));
 
         Map<String, Object> importParameters = new HashMap<>();
-        importParameters.put("randomImportParameters", "randomImportValue");
+        importParameters.put("iidm.import.xml.with-automation-systems", false);
 
         mvc.perform(post("/v1/networks")
                 .contentType(MediaType.APPLICATION_JSON)
@@ -437,6 +437,11 @@ class NetworkConversionTest {
         assertEquals(randomUuid.toString(), message.getHeaders().get(NotificationService.HEADER_NETWORK_UUID));
         assertEquals(receiver, message.getHeaders().get(NotificationService.HEADER_RECEIVER));
         assertEquals("20140116_0830_2D4_UX1_pst", message.getHeaders().get(NotificationService.HEADER_NETWORK_ID));
+
+        Map<String, Object> expectedParams = new HashMap<>();
+        Importer.find("XIIDM").getParameters().stream().forEach(parameter -> expectedParams.put(parameter.getName(), parameter.getDefaultValue()));
+        expectedParams.put("iidm.import.xml.with-automation-systems", false);
+        assertEquals(expectedParams, message.getHeaders().get(NotificationService.HEADER_IMPORT_PARAMETERS));
     }
 
     @Test


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
<!-- please use `'[x]'` to check the checkboxes, or submit the PR and then click the checkboxes -->
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] A PR or issue has been opened in all impacted repositories (if any)


**Does this PR already have an issue describing the problem?**
No.



**What kind of change does this PR introduce?**
Bug fix.



**What is the current behavior?**
Import parameters were sent as strings in the emitCaseImportSucceeded notification and the null values were sent as empty strings. This causes errors when recreating the network with those parameters.
**Also**: only modified parameters are used to convert the network.



**What is the new behavior (if this is a feature change)?**
Import parameters are sent as object with their effective value, without a weird stringification.
**Also**: now modified import parameters and default parameters are used to convert the network so that the same parameters are used for the first creation and for a recreation. 


**Does this PR introduce a breaking change or deprecate an API?**
- [x] Yes
- [ ] No

